### PR TITLE
ADD Test de l'asyncService

### DIFF
--- a/RDD.Infra.Tests/AsyncServiceTests.cs
+++ b/RDD.Infra.Tests/AsyncServiceTests.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using RDD.Domain;
+using RDD.Domain.Contexts;
+using RDD.Infra.BootStrappers;
+using RDD.Infra.Services;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace RDD.Infra.Tests
+{
+	[TestClass]
+	public class AsyncServiceTests
+	{
+		private readonly IAsyncService _asyncService;
+
+		private Mock<ICollection> _mock { get; set; }
+
+		public AsyncServiceTests()
+		{
+			TestsBootStrapper.ApplicationStart();
+			
+			_asyncService = new AsyncService();
+		}
+
+		[TestInitialize]
+		public void Init()
+		{
+			TestsBootStrapper.ApplicationBeginRequest();
+
+			_mock = new Mock<ICollection>();
+			_mock.Setup(m => m.GetEnumerator()).Verifiable();
+		}
+
+		private void CallVerifiableMockMethod()
+		{
+			_mock.Object.GetEnumerator();
+		}
+
+		[TestMethod]
+		public async Task AsyncService_ShouldBeTestable_WhenCallingContinueAsync()
+		{
+			await _asyncService.ContinueAsync(() => CallVerifiableMockMethod());
+
+			_mock.Verify(m => m.GetEnumerator(), Times.Once());
+		}
+
+		[TestMethod]
+		public void AsyncService_ShouldBeTestable_WhenCallingRunInParallel()
+		{
+			var list = new List<int> { 1, 2, 3 };
+
+			_asyncService.RunInParallel<int>(list, (number) => CallVerifiableMockMethod());
+
+			_mock.Verify(m => m.GetEnumerator(), Times.Exactly(3));
+		}
+	}
+}

--- a/RDD.Infra.Tests/Properties/AssemblyInfo.cs
+++ b/RDD.Infra.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RDD.Infra.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RDD.Infra.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("48c2e0cc-40f1-49b2-94fb-0f17fa58c0f4")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/RDD.Infra.Tests/RDD.Infra.Tests.csproj
+++ b/RDD.Infra.Tests/RDD.Infra.Tests.csproj
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{25461E71-7E9B-47BA-8018-418F58BBBFAC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RDD.Infra.Tests</RootNamespace>
+    <AssemblyName>RDD.Infra.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.0.0-alpha001\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.6.25.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.6.25-alpha\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="AsyncServiceTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RDD.Core.Infra\RDD.Infra.csproj">
+      <Project>{89444142-9c67-4e79-9261-63c1090699d1}</Project>
+      <Name>RDD.Infra</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\RDD.Domain\RDD.Domain.csproj">
+      <Project>{1254e6cb-e65c-44e5-b5bf-4f34e3af6643}</Project>
+      <Name>RDD.Domain</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/RDD.Infra.Tests/app.config
+++ b/RDD.Infra.Tests/app.config
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/></startup></configuration>

--- a/RDD.Infra.Tests/packages.config
+++ b/RDD.Infra.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="4.0.0-alpha001" targetFramework="net45" />
+  <package id="Moq" version="4.6.25-alpha" targetFramework="net45" />
+</packages>

--- a/RDD.sln
+++ b/RDD.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RDD.Web", "Web\RDD.Web\RDD.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RDD.Domain.Tests", "Domain\RDD.Domain.Tests\RDD.Domain.Tests.csproj", "{F9D5C055-3C29-46AE-8B5B-B38FD94631AB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RDD.Infra.Tests", "RDD.Infra.Tests\RDD.Infra.Tests.csproj", "{25461E71-7E9B-47BA-8018-418F58BBBFAC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{F9D5C055-3C29-46AE-8B5B-B38FD94631AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F9D5C055-3C29-46AE-8B5B-B38FD94631AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F9D5C055-3C29-46AE-8B5B-B38FD94631AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{25461E71-7E9B-47BA-8018-418F58BBBFAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{25461E71-7E9B-47BA-8018-418F58BBBFAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{25461E71-7E9B-47BA-8018-418F58BBBFAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{25461E71-7E9B-47BA-8018-418F58BBBFAC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Ces tests avaient été écrits dans WS BI pour vérifier que ContinueAsync était bien testable suite à la PR mergée précédemment (cf https://github.com/LuccaSA/RestDrivenDomain/commit/27bd4d5f795fc20d99d85b39a4833731429095c2)
Ils ont plus leur place dans RDD.