### PR TITLE
ADD: hook RefreshEntityAfterCommit

### DIFF
--- a/Web/RDD.Web/Controllers/WebApiController.http.cs
+++ b/Web/RDD.Web/Controllers/WebApiController.http.cs
@@ -94,11 +94,16 @@ namespace RDD.Web.Controllers
 
 			_execution.queryWatch.Stop();
 
-			entity = _collection.GetById(entity.Id, query, query.Verb);
+			entity = RefreshEntityAfterCommit(query, entity);
 
 			var dataContainer = new Metadata(_serializer.SerializeEntity(entity, query.Fields), query.Options);
 
 			return request.CreateResponse(HttpStatusCode.OK, dataContainer.ToDictionary(), ApiHelper.GetFormatter());
+		}
+
+		protected virtual TEntity RefreshEntityAfterCommit(Query<TEntity> query, TEntity entity)
+		{
+			return _collection.GetById(entity.Id, query, query.Verb);
 		}
 
 		public virtual HttpResponseMessage Put(TKey _id_)


### PR DESCRIPTION
Dans les controllers d'actions, la ressource n'est pas obligatoirement persistée en BD.
Si elle n'est pas persistée, le GetById jette une erreur.
Un hook overidable permettrait de simplement retourner l'entité postée, voire d'appliquer d'autres options de formatting spécifiques à la ressource de l'action.