### PR TITLE
MOD: AuthorizedOperations & AuthorizedActions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 - `GetEntityAfterCreate` method added in IRestCollection. It defines how the created entity should be returned to the client. Useful when the entity is not persisted in DB.
+- `Operations` and `Actions` are renamed into `AuthorizedOperations` and `AuthorizedActions`.
 
 ## 1.0.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New features
 - `GetEntityAfterCreate` method added in IRestCollection. It defines how the created entity should be returned to the client. Useful when the entity is not persisted in DB.
+
+### Breaking changes
 - `Operations` and `Actions` are renamed into `AuthorizedOperations` and `AuthorizedActions`.
 
 ## 1.0.11

--- a/RDD.Domain/IEntityBase.cs
+++ b/RDD.Domain/IEntityBase.cs
@@ -12,8 +12,8 @@ namespace RDD.Domain
 	{
 		string Name { get; set; }
 		string Url { get; set; }
-		ICollection<Operation> Operations { get; set; }
-		Dictionary<string, bool> Actions { get; set; }
+		ICollection<Operation> AuthorizedOperations { get; set; }
+		Dictionary<string, bool> AuthorizedActions { get; set; }
 
 		void Forge(IStorageService storage, Options queryOptions);
 	}

--- a/RDD.Domain/Models/EntityBase.cs
+++ b/RDD.Domain/Models/EntityBase.cs
@@ -15,13 +15,13 @@ namespace RDD.Domain.Models
 		public abstract TKey Id { get; set; }
 		public abstract string Name { get; set; }
 		public string Url { get; set; }
-		public ICollection<Operation> Operations { get; set; }
-		public Dictionary<string, bool> Actions { get; set; }
+		public ICollection<Operation> AuthorizedOperations { get; set; }
+		public Dictionary<string, bool> AuthorizedActions { get; set; }
 
 		public EntityBase()
 		{
-			Operations = new HashSet<Operation>();
-			Actions = new Dictionary<string, bool>();
+			AuthorizedOperations = new HashSet<Operation>();
+			AuthorizedActions = new Dictionary<string, bool>();
 		}
 
 		public virtual object GetId()

--- a/RDD.Domain/Models/Querying/Query.cs
+++ b/RDD.Domain/Models/Querying/Query.cs
@@ -152,8 +152,8 @@ namespace RDD.Domain.Models.Querying
 			}
 			//            query.ExpressionFieldsSelector = new ExpressionFieldsService().GetExpression<TEntity>(query.Fields);
 
-			Options.attachActions = Fields.Contains(e => ((IEntityBase)e).Actions);
-			Options.attachOperations = Options.attachActions || Fields.Contains(e => ((IEntityBase)e).Operations);
+			Options.attachActions = Fields.Contains(e => ((IEntityBase)e).AuthorizedActions);
+			Options.attachOperations = Options.attachActions || Fields.Contains(e => ((IEntityBase)e).AuthorizedOperations);
 
 			//Paging
 			if (parameters.ContainsKey(Reserved.paging))

--- a/RDD.Domain/Models/RestCollection.cs
+++ b/RDD.Domain/Models/RestCollection.cs
@@ -103,7 +103,7 @@ namespace RDD.Domain.Models
 			{
 				if (entityPerms.ContainsKey(el.Id))
 				{
-					el.Operations = operations.Where(op => entityPerms[el.Id].Contains(op.Id)).ToList();
+					el.AuthorizedOperations = operations.Where(op => entityPerms[el.Id].Contains(op.Id)).ToList();
 				}
 			}
 		}
@@ -527,7 +527,7 @@ namespace RDD.Domain.Models
 		public virtual PropertySelector<TEntity> HandleIncludes(PropertySelector<TEntity> includes, HttpVerb verb, Field<TEntity> fields)
 		{
 			//On n'inclut pas les propriétés qui ne viennent pas de la BDD
-			includes.Remove(t => t.Operations);
+			includes.Remove(t => t.AuthorizedOperations);
 			//includes = helper.Remove(includes, t => t.Culture);
 			//includes = helper.Remove(includes, t => t.Application);
 


### PR DESCRIPTION
@nfaugout 

Lorsqu'on échange avec les APIs Lucca, on a un décalage entre les propriétés Operations et AuthorizedOperations: ça oblige à ignorer le champ Operation actuel de RDD manuellement.