### PR TITLE
SmtpLog.Fix: 2 logs apparaissent dans le cas forceSend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 1.1.2
+
+### Resolved issues
+- FIX duplicate log in `SmtpMailService.SendMail()` method
+
 ## 1.1.1
 
 ### New features

--- a/RDD.Core.Infra/Mails/SmtpMailService.cs
+++ b/RDD.Core.Infra/Mails/SmtpMailService.cs
@@ -56,6 +56,8 @@ namespace RDD.Infra.Mails
 					};
 
 					logService.Log(LogLevel.INFO, String.Format("Smtp message sent from {0} to {1} with subject {2}", from, to, subject));
+
+					return;
 				}
 
 				logService.Log(LogLevel.INFO, String.Format("Smtp message not forced (then not sent) from {0} to {1} with subject {2}", from, to, subject));


### PR DESCRIPTION
Pour ce genre de correction mineure, on fonctionne quand même avec les pull requests ?

Est-ce une issue du point de vue du ChangeLog ?