### PR TITLE
Ajout du support des headers dans la Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## 1.1.3
+
+### New features
+- Add `Headers` property to the Query<T> to store the webrequest headers
+
 ## 1.1.2
 
 ### Resolved issues

--- a/Domain/RDD.Domain.Tests/Models/Querying/HeadersTests.cs
+++ b/Domain/RDD.Domain.Tests/Models/Querying/HeadersTests.cs
@@ -1,0 +1,66 @@
+﻿using NUnit.Framework;
+using RDD.Domain.Models.Querying;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RDD.Domain.Tests.Models.Querying
+{
+	public class HeadersTests
+	{
+		[Test]
+		public void Headers_ShouldParseIfUnmodifiedSinceHeader()
+		{
+			var date = new DateTime(2015, 9, 21, 7, 28, 0);
+			var requestHeaders = new NameValueCollection { { "If-Unmodified-Since", date.ToString("ddd, dd MMM yyyy HH:mm:ss zzz") } };
+
+			var headers = Headers.Parse(requestHeaders);
+
+			Assert.AreEqual(0, DateTime.Compare(date, headers.IfUnmodifiedSince));
+		}
+
+		[Test]
+		public void Headers_ShouldParseAuthorizationHeader()
+		{
+			var authorization = "anything here";
+			var requestHeaders = new NameValueCollection { { "Authorization", authorization } };
+
+			var headers = Headers.Parse(requestHeaders);
+
+			Assert.AreEqual(authorization, headers.Authorization);
+		}
+
+		[Test]
+		public void Headers_ShouldParseContentTypeHeader()
+		{
+			var contentType = "multipart/form-data";
+			var requestHeaders = new NameValueCollection { { "Content-Type", contentType } };
+
+			var headers = Headers.Parse(requestHeaders);
+
+			Assert.AreEqual(contentType, headers.ContentType);
+		}
+
+		[Test]
+		public void Headers_ShouldParseRawHeaders()
+		{
+			var requestHeaders = new NameValueCollection
+			{
+				{ "Content-Type", "multipart/form-data" },
+				{ "any", "value" },
+				{ "Foo", "Bar" },
+			};
+
+			var headers = Headers.Parse(requestHeaders);
+
+			Assert.AreEqual(3, headers.RawHeaders.Count);
+
+			Assert.AreEqual("multipart/form-data", headers.RawHeaders["Content-Type"]);
+			Assert.AreEqual("value", headers.RawHeaders["any"]);
+			Assert.AreEqual("Bar", headers.RawHeaders["Foo"]);
+		}
+	}
+}

--- a/Domain/RDD.Domain.Tests/Models/Querying/HeadersTests.cs
+++ b/Domain/RDD.Domain.Tests/Models/Querying/HeadersTests.cs
@@ -1,11 +1,7 @@
 ﻿using NUnit.Framework;
 using RDD.Domain.Models.Querying;
 using System;
-using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RDD.Domain.Tests.Models.Querying
 {
@@ -19,7 +15,18 @@ namespace RDD.Domain.Tests.Models.Querying
 
 			var headers = Headers.Parse(requestHeaders);
 
-			Assert.AreEqual(0, DateTime.Compare(date, headers.IfUnmodifiedSince));
+			Assert.AreEqual(true, headers.IfUnmodifiedSince.HasValue);
+			Assert.AreEqual(0, DateTime.Compare(date, headers.IfUnmodifiedSince.Value));
+		}
+
+		[Test]
+		public void Headers_ShouldNotParseIfUnmodifiedSinceHeader_WhenDateFormatIsInvalid()
+		{
+			var requestHeaders = new NameValueCollection { { "If-Unmodified-Since", "invalid format" } };
+
+			var headers = Headers.Parse(requestHeaders);
+
+			Assert.AreEqual(false, headers.IfUnmodifiedSince.HasValue);
 		}
 
 		[Test]

--- a/Domain/RDD.Domain.Tests/RDD.Domain.Tests.csproj
+++ b/Domain/RDD.Domain.Tests/RDD.Domain.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="HttpLikeExceptionsTests.cs" />
     <Compile Include="CollectionPropertiesTests.cs" />
     <Compile Include="DecimalRoundingTests.cs" />
+    <Compile Include="Models\Querying\HeadersTests.cs" />
     <Compile Include="Models\UsersCollection.cs" />
     <Compile Include="Models\User.cs" />
     <Compile Include="CollectionMethodsTests.cs" />

--- a/RDD.Domain/Models/Querying/Headers.cs
+++ b/RDD.Domain/Models/Querying/Headers.cs
@@ -10,7 +10,7 @@ namespace RDD.Domain.Models.Querying
 			RawHeaders = new NameValueCollection();
 		}
 
-		public DateTime IfUnmodifiedSince { get; set; }
+		public DateTime? IfUnmodifiedSince { get; set; }
 		public string Authorization { get; set; }
 		public string ContentType { get; set; }
 
@@ -27,9 +27,11 @@ namespace RDD.Domain.Models.Querying
 				switch (key)
 				{
 					case "If-Unmodified-Since":
-						DateTime dateTime;
-						DateTime.TryParse(requestHeaders[key], out dateTime);
-						headers.IfUnmodifiedSince = dateTime;
+						DateTime unModifiedSince;
+						if (DateTime.TryParse(requestHeaders[key], out unModifiedSince))
+						{
+							headers.IfUnmodifiedSince = unModifiedSince;
+						}
 						break;
 
 					case "Authorization":

--- a/RDD.Domain/Models/Querying/Headers.cs
+++ b/RDD.Domain/Models/Querying/Headers.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Specialized;
+
+namespace RDD.Domain.Models.Querying
+{
+	public class Headers
+	{
+		public Headers()
+		{
+			RawHeaders = new NameValueCollection();
+		}
+
+		public string IfUnmodifiedSince { get; set; }
+		public string Authorization { get; set; }
+		public string ContentType { get; set; }
+
+		public NameValueCollection RawHeaders { get; set; }
+
+		public static Headers Parse(NameValueCollection requestHeaders)
+		{
+			var headers = new Headers();
+
+			foreach (var key in requestHeaders.AllKeys)
+			{
+				switch (key)
+				{
+					case "If-Unmodified-Since":
+						headers.IfUnmodifiedSince = requestHeaders[key];
+						break;
+
+					case "Authorization":
+						headers.Authorization = requestHeaders[key];
+						break;
+
+					case "Content-Type":
+						headers.ContentType = requestHeaders[key];
+						break;
+				}
+
+				headers.RawHeaders.Add(key, requestHeaders[key]);
+			}
+
+			return headers;
+		}
+	}
+}

--- a/RDD.Domain/Models/Querying/Headers.cs
+++ b/RDD.Domain/Models/Querying/Headers.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Specialized;
+﻿using System;
+using System.Collections.Specialized;
 
 namespace RDD.Domain.Models.Querying
 {
@@ -9,7 +10,7 @@ namespace RDD.Domain.Models.Querying
 			RawHeaders = new NameValueCollection();
 		}
 
-		public string IfUnmodifiedSince { get; set; }
+		public DateTime IfUnmodifiedSince { get; set; }
 		public string Authorization { get; set; }
 		public string ContentType { get; set; }
 
@@ -19,12 +20,16 @@ namespace RDD.Domain.Models.Querying
 		{
 			var headers = new Headers();
 
+			headers.RawHeaders = requestHeaders;
+
 			foreach (var key in requestHeaders.AllKeys)
 			{
 				switch (key)
 				{
 					case "If-Unmodified-Since":
-						headers.IfUnmodifiedSince = requestHeaders[key];
+						DateTime dateTime;
+						DateTime.TryParse(requestHeaders[key], out dateTime);
+						headers.IfUnmodifiedSince = dateTime;
 						break;
 
 					case "Authorization":
@@ -35,8 +40,6 @@ namespace RDD.Domain.Models.Querying
 						headers.ContentType = requestHeaders[key];
 						break;
 				}
-
-				headers.RawHeaders.Add(key, requestHeaders[key]);
 			}
 
 			return headers;

--- a/RDD.Domain/Models/Querying/Query.cs
+++ b/RDD.Domain/Models/Querying/Query.cs
@@ -4,9 +4,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RDD.Domain.Models.Querying
 {
@@ -59,6 +56,7 @@ namespace RDD.Domain.Models.Querying
 		public Func<TEntity, object> ExpressionFieldsSelector { get; set; }
 		public Field<TEntity> Fields { get; set; }
 		public virtual Options Options { get; set; }
+		public Headers Headers { get; set; }
 		public PropertySelector<TEntity> Includes { get; set; }
 
 		protected HashSet<string> IgnoredFilters { get; set; }
@@ -68,6 +66,7 @@ namespace RDD.Domain.Models.Querying
 			Verb = HttpVerb.GET;
 			OrderBys = new List<OrderBy>();
 			Options = new Options();
+			Headers = new Headers();
 			Filters = new List<Where>();
 			Includes = new PropertySelector<TEntity>();
 			Fields = new Field<TEntity>();
@@ -98,6 +97,8 @@ namespace RDD.Domain.Models.Querying
 
 		public Query<TEntity> Parse(IWebContext webContext, bool isCollectionCall = true)
 		{
+			Headers = Headers.Parse(webContext.Headers);
+
 			//On transforme la queryString en PostedData pour que ce soit plus simple à manipuler ensuite
 			var parameters = PostedData.ParseDictionary(webContext.GetQueryNameValuePairs().Where(v => !IgnoredFilters.Contains(v.Key)).ToDictionary(K => K.Key.ToLower(), K => K.Value));
 

--- a/RDD.Domain/RDD.Domain.csproj
+++ b/RDD.Domain/RDD.Domain.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Models\Operation.cs" />
     <Compile Include="Models\Period.cs" />
     <Compile Include="Models\Querying\Field.cs" />
+    <Compile Include="Models\Querying\Headers.cs" />
     <Compile Include="Models\Querying\Options.cs" />
     <Compile Include="Models\Querying\OrderBy.cs" />
     <Compile Include="Models\Querying\Page.cs" />


### PR DESCRIPTION
On rajoute une propriété Headers sur la Query<T>.
Elle peut ensuite être exploitée notamment par le SDK pour requêter Lucca avec les headers souhaités.