### PR TITLE
Vs2k17.bigchanges

### DIFF
--- a/Application/RDD.Application/Controllers/AppController.cs
+++ b/Application/RDD.Application/Controllers/AppController.cs
@@ -1,4 +1,5 @@
-﻿using RDD.Domain;
+﻿using NExtends.Primitives.Types;
+using RDD.Domain;
 using RDD.Domain.Helpers;
 using RDD.Domain.Models.Querying;
 using System;
@@ -8,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace RDD.Application.Controllers
 {
-    public class AppController<TCollection, TEntity, TKey> : ReadOnlyAppController<TCollection, TEntity, TKey>, IAppController<TCollection, TEntity, TKey>
+    public class AppController<TCollection, TEntity, TKey> : ReadOnlyAppController<TCollection, TEntity, TKey>, IAppController<TEntity, TKey>
         where TCollection : IRestCollection<TEntity, TKey>
         where TEntity : class, IEntityBase<TEntity, TKey>, new()
         where TKey : IEquatable<TKey>

--- a/Application/RDD.Application/Controllers/ReadOnlyAppController.cs
+++ b/Application/RDD.Application/Controllers/ReadOnlyAppController.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace RDD.Application.Controllers
 {
-    public class ReadOnlyAppController<TCollection, TEntity, TKey> : IReadOnlyAppController<TCollection, TEntity, TKey>
+    public class ReadOnlyAppController<TCollection, TEntity, TKey> : IReadOnlyAppController<TEntity, TKey>
         where TCollection : IReadOnlyRestCollection<TEntity, TKey>
         where TEntity : class, IEntityBase<TEntity, TKey>, new()
         where TKey : IEquatable<TKey>

--- a/Application/RDD.Application/IAppController.cs
+++ b/Application/RDD.Application/IAppController.cs
@@ -6,13 +6,6 @@ using System.Threading.Tasks;
 
 namespace RDD.Application
 {
-    public interface IAppController<TCollection, TEntity, TKey> : IReadOnlyAppController<TCollection, TEntity, TKey>, IAppController<TEntity, TKey>
-        where TCollection : IRestCollection<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>, new()
-        where TKey : IEquatable<TKey>
-    {
-    }
-
     public interface IAppController<TEntity, TKey> : IReadOnlyAppController<TEntity, TKey>
         where TEntity : class, IEntityBase<TEntity, TKey>, new()
         where TKey : IEquatable<TKey>

--- a/Application/RDD.Application/IReadOnlyAppController.cs
+++ b/Application/RDD.Application/IReadOnlyAppController.cs
@@ -5,13 +5,6 @@ using System.Threading.Tasks;
 
 namespace RDD.Application
 {
-    public interface IReadOnlyAppController<TCollection, TEntity, TKey> : IReadOnlyAppController<TEntity, TKey>
-        where TCollection : IReadOnlyRestCollection<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>, new()
-        where TKey : IEquatable<TKey>
-    {
-    }
-
     public interface IReadOnlyAppController<TEntity, TKey>
         where TEntity : class, IEntityBase<TEntity, TKey>, new()
         where TKey : IEquatable<TKey>

--- a/Infra/RDD.Infra/Contexts/HttpContextWrapper.cs
+++ b/Infra/RDD.Infra/Contexts/HttpContextWrapper.cs
@@ -12,7 +12,7 @@ using System.Threading;
 
 namespace RDD.Infra.Contexts
 {
-    public class HttpContextWrapper : IWebContext, IWebContextWrapper
+    public class HttpContextWrapper : IWebContextWrapper
     {
         public Uri Url { get; private set; }
         public string RawUrl { get; private set; }

--- a/Infra/RDD.Infra/Storage/InMemoryStorageService.cs
+++ b/Infra/RDD.Infra/Storage/InMemoryStorageService.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace RDD.Infra.Storage
 {
-    public class InMemoryStorageService : IStorageService, IDisposable
+    public class InMemoryStorageService : IStorageService
     {
         protected Queue<Task> _afterAfterSaveChangesActions { get; set; }
         public Dictionary<Type, IList> Cache { get; }


### PR DESCRIPTION
Je retire TCollection des interfaces, car c'est sans utilité d'un point de vue type sur l'interface (pas exploité) et c'est un détail d'implémentation des classes concrètes (question de la responsabilité)

Peut avoir un impact sur l'existant