### PR TITLE
Async methods for WebClient (addresses #51)

### DIFF
--- a/RDD.Domain/IWebClient.cs
+++ b/RDD.Domain/IWebClient.cs
@@ -26,5 +26,14 @@ namespace RDD.Domain
 		byte[] UploadFile(string address, string method, string fileName);
 		byte[] UploadData(string address, string method, byte[] data);
 		byte[] UploadValues(string address, string method, NameValueCollection data);
-	}
+
+        Task<string> DownloadStringTaskAsync(string address);
+        Task<string> UploadStringTaskAsync(string address, string data);
+        Task<string> UploadStringTaskAsync(string address, string method, string data);
+
+        Task<byte[]> DownloadDataTaskAsync(string address);
+        Task<byte[]> UploadFileTaskAsync(string address, string method, string fileName);
+        Task<byte[]> UploadDataTaskAsync(string address, string method, byte[] data);
+        Task<byte[]> UploadValuesTaskAsync(string address, string method, NameValueCollection data);
+    }
 }

--- a/RDD.Domain/IWebClient.cs
+++ b/RDD.Domain/IWebClient.cs
@@ -19,7 +19,7 @@ namespace RDD.Domain
 
 		// Required methods (subset of `System.Net.WebClient` methods).
 		string DownloadString(string address);
-		string UploadString(string address, string method);
+		string UploadString(string address, string data);
 		string UploadString(string address, string method, string data);
 
 		byte[] DownloadData(string address);


### PR DESCRIPTION
### Async methods for WebClient

The [IWebClient interface](https://github.com/LuccaSA/RestDrivenDomain/blob/5e4b76e004c4113bf78b6b3402cad8b158b2e579/RDD.Domain/IWebClient.cs) lacks async methods. This PR declares new methods that mirror existing ones, using async/await and returning `Task<>`s.

Also correcting a minor typo in one of the existing declarations.