### PR TITLE
REF : migrate to NExtends 2.1.0

### DIFF
--- a/Domain/RDD.Domain.Tests/Models/Querying/HeadersTests.cs
+++ b/Domain/RDD.Domain.Tests/Models/Querying/HeadersTests.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.Extensions.Primitives;
-using NExtends.Primitives;
+using NExtends.Primitives.Generics;
+using RDD.Web.Querying;
 using System;
 using System.Collections.Generic;
 using Xunit;
-using RDD.Web.Querying;
 
 namespace RDD.Domain.Tests.Models.Querying
 {

--- a/Domain/RDD.Domain/Helpers/CollectionPropertySelector.cs
+++ b/Domain/RDD.Domain/Helpers/CollectionPropertySelector.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using NExtends.Primitives.Strings;
+using RDD.Domain.Exceptions;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using NExtends.Primitives;
-using RDD.Domain.Exceptions;
 
 namespace RDD.Domain.Helpers
 {

--- a/Domain/RDD.Domain/Helpers/PatchEntityHelper.cs
+++ b/Domain/RDD.Domain/Helpers/PatchEntityHelper.cs
@@ -1,15 +1,14 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using NExtends.Primitives.Strings;
+using NExtends.Primitives.Types;
+using RDD.Domain.Exceptions;
+using RDD.Domain.Models.Querying;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Net;
 using System.Reflection;
-using Newtonsoft.Json;
-using NExtends.Primitives;
-using NExtends.Primitives.Types;
-using RDD.Domain.Exceptions;
-using RDD.Domain.Models.Querying;
 
 namespace RDD.Domain.Helpers
 {

--- a/Domain/RDD.Domain/Helpers/PropertySelector.cs
+++ b/Domain/RDD.Domain/Helpers/PropertySelector.cs
@@ -1,13 +1,12 @@
-﻿using System;
+﻿using NExtends.Primitives.Strings;
+using NExtends.Primitives.Types;
+using RDD.Domain.Exceptions;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Net;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using NExtends.Primitives;
-using NExtends.Primitives.Types;
-using RDD.Domain.Exceptions;
 
 namespace RDD.Domain.Helpers
 {

--- a/Domain/RDD.Domain/Models/Enum.cs
+++ b/Domain/RDD.Domain/Models/Enum.cs
@@ -1,7 +1,7 @@
-﻿using RDD.Domain.Attributes;
+﻿using NExtends.Primitives.Enums;
+using RDD.Domain.Attributes;
 using System;
 using System.Linq;
-using NExtends.Primitives;
 
 namespace RDD.Domain.Models
 {

--- a/Domain/RDD.Domain/Models/Period.cs
+++ b/Domain/RDD.Domain/Models/Period.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using NExtends.Primitives.DateTimes;
+using System;
 using System.Collections.Generic;
-using NExtends.Primitives;
 
 namespace RDD.Domain.Models
 {

--- a/Domain/RDD.Domain/Models/Querying/PostedData.cs
+++ b/Domain/RDD.Domain/Models/Querying/PostedData.cs
@@ -1,9 +1,9 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NExtends.Primitives.DateTimes;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using NExtends.Primitives;
 
 namespace RDD.Domain.Models.Querying
 {
@@ -228,7 +228,6 @@ namespace RDD.Domain.Models.Querying
         }
 
         public bool ContainsKey(string key) => Subs.ContainsKey(key);
-        public bool ContainsKey(Enum key) => Subs.ContainsKey(key);
         public bool Remove(string key) => Subs.Remove(key);
         public int Count() => Subs.Count;
     }

--- a/Domain/RDD.Domain/Models/Querying/SerializationService.cs
+++ b/Domain/RDD.Domain/Models/Querying/SerializationService.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using NExtends.Primitives.DateTimes;
+using NExtends.Primitives.Strings;
+using NExtends.Primitives.Types;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -6,8 +9,6 @@ using System.Linq;
 using System.Net.Mail;
 using System.Reflection;
 using System.Runtime.Serialization;
-using NExtends.Primitives;
-using NExtends.Primitives.Types;
 
 namespace RDD.Domain.Models.Querying
 {

--- a/Domain/RDD.Domain/RDD.Domain.csproj
+++ b/Domain/RDD.Domain/RDD.Domain.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="1.1.11" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.0.0" />
-    <PackageReference Include="NExtends" Version="2.0.0" />
+    <PackageReference Include="NExtends" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Web/RDD.Web/Querying/FiltersParser.cs
+++ b/Web/RDD.Web/Querying/FiltersParser.cs
@@ -3,11 +3,13 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using NExtends.Primitives;
+using NExtends.Primitives.DateTimes;
+using NExtends.Primitives.Strings;
 using RDD.Domain;
 using RDD.Domain.Helpers;
 using RDD.Domain.Models;
 using RDD.Domain.Models.Querying;
+using Newtonsoft.Json;
 
 namespace RDD.Web.Querying
 {
@@ -57,7 +59,7 @@ namespace RDD.Web.Querying
                 }
                 else
                 {
-                    data = PostedData.ParseJsonArray(JArray.Parse("[" + string.Join(", ", stringValue.Split(',').Select(p => p.ToJSON()).ToArray()) + "]"));
+                    data = PostedData.ParseJsonArray(JArray.Parse("[" + string.Join(", ", stringValue.Split(',').Select(p => JsonConvert.SerializeObject(p)).ToArray()) + "]"));
                 }
 
                 var type = FilterOperand.Equals;


### PR DESCRIPTION
- string.ToJson() replaced by former NExtends implementation : https://github.com/LuccaSA/NExtends/blob/dc2e91ef781869dd1f9a5cc055aa8a1e58f55003/NExtends/Primitives/Strings/String.extensions.cs#L169
- PostedData.ContainsKey(Enum key) is removed