### PR TITLE
Brk.entity base constraints

### DIFF
--- a/Application/RDD.Application/Controllers/AppController.cs
+++ b/Application/RDD.Application/Controllers/AppController.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace RDD.Application.Controllers
 {
     public class AppController<TEntity, TKey> : AppController<IRestCollection<TEntity, TKey>, TEntity, TKey> 
-        where TEntity : class, IEntityBase<TEntity, TKey>, new()
+        where TEntity : class, IEntityBase<TEntity, TKey>
         where TKey : IEquatable<TKey>
     {
         public AppController(IStorageService storage, IRestCollection<TEntity, TKey> collection) 
@@ -19,7 +19,7 @@ namespace RDD.Application.Controllers
 
     public class AppController<TCollection, TEntity, TKey> : ReadOnlyAppController<TCollection, TEntity, TKey>, IAppController<TEntity, TKey>
         where TCollection : IRestCollection<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>, new()
+        where TEntity : class, IEntityBase<TEntity, TKey>
         where TKey : IEquatable<TKey>
     {
         protected IStorageService Storage { get; }

--- a/Application/RDD.Application/IAppController.cs
+++ b/Application/RDD.Application/IAppController.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace RDD.Application
 {
     public interface IAppController<TEntity, TKey> : IReadOnlyAppController<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>, new()
+        where TEntity : class, IEntityBase<TEntity, TKey>
         where TKey : IEquatable<TKey>
     {
         Task<TEntity> CreateAsync(PostedData datas, Query<TEntity> query);

--- a/Domain/RDD.Domain.Tests/CollectionMethodsTests.cs
+++ b/Domain/RDD.Domain.Tests/CollectionMethodsTests.cs
@@ -9,6 +9,7 @@ using RDD.Domain.WebServices;
 using RDD.Infra.Storage;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace RDD.Domain.Tests
@@ -16,7 +17,7 @@ namespace RDD.Domain.Tests
     public class CollectionMethodsTests : SingleContextTests
     {
         [Fact]
-        public async void GetById_SHOULD_throw_exception_WHEN_id_does_not_exist()
+        public async Task GetById_SHOULD_throw_exception_WHEN_id_does_not_exist()
         {
             using (var storage = _newStorage(Guid.NewGuid().ToString()))
             {
@@ -33,7 +34,7 @@ namespace RDD.Domain.Tests
         }
 
         [Fact]
-        public async void TryGetById_SHOULD_not_throw_exception_and_return_null_WHEN_id_does_not_exist()
+        public async Task TryGetById_SHOULD_not_throw_exception_and_return_null_WHEN_id_does_not_exist()
         {
             using (var storage = _newStorage(Guid.NewGuid().ToString()))
             {
@@ -50,7 +51,7 @@ namespace RDD.Domain.Tests
         }
 
         [Fact]
-        public async void Put_SHOULD_throw_notfound_exception_WHEN_unexisting_entity_()
+        public async Task Put_SHOULD_throw_notfound_exception_WHEN_unexisting_entity_()
         {
             using (var storage = _newStorage(Guid.NewGuid().ToString()))
             {
@@ -76,7 +77,7 @@ namespace RDD.Domain.Tests
         }
 
         [Fact]
-        public async void Post_SHOULD_work_WHEN_InstantiateEntityIsNotOverridenAndEntityHasAParameterlessConstructor()
+        public async Task Post_SHOULD_work_WHEN_InstantiateEntityIsNotOverridenAndEntityHasAParameterlessConstructor()
         {
             using (var storage = _newStorage(Guid.NewGuid().ToString()))
             {
@@ -90,7 +91,7 @@ namespace RDD.Domain.Tests
         }
 
         [Fact]
-        public async void Post_SHOULD_work_WHEN_InstantiateEntityIsOverriden()
+        public async Task Post_SHOULD_work_WHEN_InstantiateEntityIsOverriden()
         {
             using (var storage = _newStorage(Guid.NewGuid().ToString()))
             {
@@ -105,7 +106,7 @@ namespace RDD.Domain.Tests
 
 
         [Fact]
-        public async void Post_SHOULD_fail_WHEN_InstantiateEntityIsNotOverridenAndEntityHasParametersInConstructor()
+        public async Task Post_SHOULD_fail_WHEN_InstantiateEntityIsNotOverridenAndEntityHasParametersInConstructor()
         {
             using (var storage = _newStorage(Guid.NewGuid().ToString()))
             {
@@ -121,7 +122,7 @@ namespace RDD.Domain.Tests
         }
 
         [Fact]
-        public async void Post_SHOULD_work_WHEN_InstantiateEntityIsOverridenAndEntityHasParametersInConstructor()
+        public async Task Post_SHOULD_work_WHEN_InstantiateEntityIsOverridenAndEntityHasParametersInConstructor()
         {
             using (var storage = _newStorage(Guid.NewGuid().ToString()))
             {

--- a/Domain/RDD.Domain.Tests/CollectionMethodsTests.cs
+++ b/Domain/RDD.Domain.Tests/CollectionMethodsTests.cs
@@ -74,5 +74,21 @@ namespace RDD.Domain.Tests
                 await Assert.ThrowsAsync<NotFoundException>(() => app.UpdateByIdAsync(0, PostedData.ParseJson(@"{ ""name"": ""new name"" }"), new Query<User>()));
             }
         }
+
+        [Fact]
+        public async void Post_SHOULD_work_WHEN_instanceIsNotOverriden()
+        {
+            using (var storage = _newStorage(Guid.NewGuid().ToString()))
+            {
+                var repo = new Repository<User>(storage, _execution, null);
+                var users = new UsersCollection(repo, _execution, null);
+                var query = new Query<User>();
+                query.Options.NeedFilterRights = false;
+                
+                await users.CreateAsync(PostedData.ParseJson(@"{ ""id"": 3 }"), query);
+
+//                await Assert.ThrowsAsync<NotFoundException>(() => app.UpdateByIdAsync(0, PostedData.ParseJson(@"{ ""name"": ""new name"" }"), new Query<User>()));
+            }
+        }
     }
 }

--- a/Domain/RDD.Domain.Tests/Models/DataContext.cs
+++ b/Domain/RDD.Domain.Tests/Models/DataContext.cs
@@ -12,6 +12,7 @@ namespace RDD.Domain.Tests.Models
         public DbSet<ConcreteClassThree> ConcreteClassThree { get; }
         public DbSet<AbstractClass> AbstractClass { get; }
         public DbSet<User> User { get; }
+        public DbSet<UserWithParameters> UserWithParameters { get; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -22,6 +23,10 @@ namespace RDD.Domain.Tests.Models
             modelBuilder.Entity<User>().Ignore(u => u.Url);
             modelBuilder.Entity<User>().Ignore(u => u.Mail);
             modelBuilder.Entity<User>().Ignore(u => u.TwitterUri);
+
+            modelBuilder.Entity<UserWithParameters>().Ignore(u => u.Url);
+            modelBuilder.Entity<UserWithParameters>().Ignore(u => u.Mail);
+            modelBuilder.Entity<UserWithParameters>().Ignore(u => u.TwitterUri);
         }
     }
 }

--- a/Domain/RDD.Domain.Tests/Models/UserWithParameters.cs
+++ b/Domain/RDD.Domain.Tests/Models/UserWithParameters.cs
@@ -1,0 +1,36 @@
+﻿using RDD.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Net.Mail;
+
+namespace RDD.Domain.Tests.Models
+{
+    public class UserWithParameters : EntityBase<UserWithParameters, int>
+    {
+        public override int Id { get; set; }
+        public override string Name { get; set; }
+        public MailAddress Mail { get; set; }
+        public Uri TwitterUri { get; set; }
+        public decimal Salary { get; set; }
+
+        public UserWithParameters(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public static IEnumerable<User> GetManyRandomUsers(int howMuch)
+        {
+            var result = new List<User>();
+
+            for (var i = 1; i <= howMuch; i++)
+            {
+                var name = $"John Doe {i}";
+
+                result.Add(new User { Id = i, Name = name });
+            }
+
+            return result;
+        }
+    }
+}

--- a/Domain/RDD.Domain.Tests/Models/UsersCollection.cs
+++ b/Domain/RDD.Domain.Tests/Models/UsersCollection.cs
@@ -6,5 +6,10 @@ namespace RDD.Domain.Tests.Models
     {
         public UsersCollection(IRepository<User> repository, IExecutionContext execution, ICombinationsHolder combinationsHolder)
             : base(repository, execution, combinationsHolder) { }
+
+        public override User InstanciateEntity()
+        {
+            return new User();
+        }
     }
 }

--- a/Domain/RDD.Domain.Tests/Models/UsersCollection.cs
+++ b/Domain/RDD.Domain.Tests/Models/UsersCollection.cs
@@ -6,10 +6,5 @@ namespace RDD.Domain.Tests.Models
     {
         public UsersCollection(IRepository<User> repository, IExecutionContext execution, ICombinationsHolder combinationsHolder)
             : base(repository, execution, combinationsHolder) { }
-
-        public override User InstanciateEntity()
-        {
-            return new User();
-        }
     }
 }

--- a/Domain/RDD.Domain.Tests/Models/UsersCollectionWithOverride.cs
+++ b/Domain/RDD.Domain.Tests/Models/UsersCollectionWithOverride.cs
@@ -1,0 +1,16 @@
+﻿using RDD.Domain.Models;
+using RDD.Domain.Models.Querying;
+
+namespace RDD.Domain.Tests.Models
+{
+    public class UsersCollectionWithOverride : RestCollection<User, int>
+    {
+        public UsersCollectionWithOverride(IRepository<User> repository, IExecutionContext execution, ICombinationsHolder combinationsHolder)
+            : base(repository, execution, combinationsHolder) { }
+
+        public override User InstanciateEntity(PostedData datas)
+        {
+            return new User();
+        }
+    }
+}

--- a/Domain/RDD.Domain.Tests/Models/UsersCollectionWithParameters.cs
+++ b/Domain/RDD.Domain.Tests/Models/UsersCollectionWithParameters.cs
@@ -1,0 +1,10 @@
+﻿using RDD.Domain.Models;
+
+namespace RDD.Domain.Tests.Models
+{
+    public class UsersCollectionWithParameters : RestCollection<UserWithParameters, int>
+    {
+        public UsersCollectionWithParameters(IRepository<UserWithParameters> repository, IExecutionContext execution, ICombinationsHolder combinationsHolder)
+            : base(repository, execution, combinationsHolder) { }
+    }
+}

--- a/Domain/RDD.Domain.Tests/Models/UsersCollectionWithParametersAndOverride.cs
+++ b/Domain/RDD.Domain.Tests/Models/UsersCollectionWithParametersAndOverride.cs
@@ -1,0 +1,20 @@
+﻿using RDD.Domain.Models;
+using RDD.Domain.Models.Querying;
+using System;
+
+namespace RDD.Domain.Tests.Models
+{
+    public class UsersCollectionWithParametersAndOverride : RestCollection<UserWithParameters, int>
+    {
+        public UsersCollectionWithParametersAndOverride(IRepository<UserWithParameters> repository, IExecutionContext execution, ICombinationsHolder combinationsHolder)
+            : base(repository, execution, combinationsHolder) { }
+
+        public override UserWithParameters InstanciateEntity(PostedData datas)
+        {
+            var id = Convert.ToInt32(datas["id"].Value);
+            var name = datas["name"].Value;
+
+            return new UserWithParameters(id, name);
+        }
+    }
+}

--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -27,11 +27,11 @@ namespace RDD.Domain.Models
 
         public virtual Task<TEntity> CreateAsync(PostedData datas, Query<TEntity> query = null)
         {
-            TEntity entity = InstanciateEntity();
+            TEntity entity = InstanciateEntity(datas);
 
             GetPatcher().PatchEntity(entity, datas);
 
-            return CreateAsync(entity);
+            return CreateAsync(entity, query);
         }
 
         public virtual async Task<TEntity> CreateAsync(TEntity entity, Query<TEntity> query = null)
@@ -120,7 +120,7 @@ namespace RDD.Domain.Models
         /// https://blogs.msdn.microsoft.com/seteplia/2017/02/01/dissecting-the-new-constraint-in-c-a-perfect-example-of-a-leaky-abstraction/
         /// </summary>
         /// <returns></returns>
-        public virtual TEntity InstanciateEntity()
+        public virtual TEntity InstanciateEntity(PostedData datas)
         {
             return System.Activator.CreateInstance<TEntity>();
         }

--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -11,7 +11,7 @@ using RDD.Domain.Models.Querying;
 namespace RDD.Domain.Models
 {
     public class RestCollection<TEntity, TKey> : ReadOnlyRestCollection<TEntity, TKey>, IRestCollection<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>, new()
+        where TEntity : class, IEntityBase<TEntity, TKey>
         where TKey : IEquatable<TKey>
     {
         public RestCollection(IRepository<TEntity> repository, IExecutionContext execution, ICombinationsHolder combinationsHolder)
@@ -115,7 +115,13 @@ namespace RDD.Domain.Models
                 Repository.Remove(entity);
             }
         }
-        public virtual TEntity InstanciateEntity() => new TEntity();
+
+        /// <summary>
+        /// We dropped the new() constraint for all these reasons
+        /// https://blogs.msdn.microsoft.com/seteplia/2017/02/01/dissecting-the-new-constraint-in-c-a-perfect-example-of-a-leaky-abstraction/
+        /// </summary>
+        /// <returns></returns>
+        public virtual TEntity InstanciateEntity() => throw new NotImplementedException();
 
         protected virtual Task CheckRightsForCreateAsync(TEntity entity)
         {

--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using RDD.Domain.Exceptions;
 using RDD.Domain.Helpers;
 using RDD.Domain.Models.Querying;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace RDD.Domain.Models
 {
@@ -121,7 +120,10 @@ namespace RDD.Domain.Models
         /// https://blogs.msdn.microsoft.com/seteplia/2017/02/01/dissecting-the-new-constraint-in-c-a-perfect-example-of-a-leaky-abstraction/
         /// </summary>
         /// <returns></returns>
-        public virtual TEntity InstanciateEntity() => throw new NotImplementedException();
+        public virtual TEntity InstanciateEntity()
+        {
+            return System.Activator.CreateInstance<TEntity>();
+        }
 
         protected virtual Task CheckRightsForCreateAsync(TEntity entity)
         {

--- a/Web/RDD.Web/Controllers/WebController.cs
+++ b/Web/RDD.Web/Controllers/WebController.cs
@@ -16,7 +16,7 @@ using RDD.Web.Models;
 namespace RDD.Web.Controllers
 {
     public abstract class WebController<TEntity, TKey> : WebController<IAppController<TEntity, TKey>, TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>, new()
+        where TEntity : class, IEntityBase<TEntity, TKey>
         where TKey : IEquatable<TKey>
     {
         protected WebController(IAppController<TEntity, TKey> appController, ApiHelper<TEntity, TKey> helper) 
@@ -27,7 +27,7 @@ namespace RDD.Web.Controllers
 
     public abstract class WebController<TAppController, TEntity, TKey> : ReadOnlyWebController<TAppController, TEntity, TKey>
         where TAppController : IAppController<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>, new()
+        where TEntity : class, IEntityBase<TEntity, TKey>
         where TKey : IEquatable<TKey>
     {
         protected WebController(TAppController appController, ApiHelper<TEntity, TKey> helper)

--- a/Web/RDD.Web/Serialization/EntitySerializer.cs
+++ b/Web/RDD.Web/Serialization/EntitySerializer.cs
@@ -25,7 +25,7 @@ namespace RDD.Web.Serialization
         }
 
         protected void Map<TEntity, TSerializer>(Func<IEntitySerializer, TSerializer> Initiator)
-            where TSerializer : PropertySerializer, new()
+            where TSerializer : PropertySerializer
         {
             var serializer = Initiator(this);
             _mappings.Add(typeof(TEntity), serializer);


### PR DESCRIPTION
Only last commit correspond to this PR.

The idea here is to removed the new( ) constraint even on r/w RestCollection.

This is an assume breaking change, in order to force consumers to override InstantiateEntity and thus know what they are doing with their entities.

@Poltuu @rducom we have to agree on this, do you ?