### PR TITLE
MOD : Put & Post scenario

### DIFF
--- a/Application/RDD.Application/Controllers/AppController.cs
+++ b/Application/RDD.Application/Controllers/AppController.cs
@@ -36,10 +36,6 @@ namespace RDD.Application.Controllers
 
             await Storage.SaveChangesAsync();
 
-            query.Options.CheckRights = false;
-
-            entity = await Collection.GetByIdAsync(entity.Id, query);
-
             return entity;
         }
 
@@ -48,12 +44,6 @@ namespace RDD.Application.Controllers
             var entity = await Collection.UpdateByIdAsync(id, datas, query);
 
             await Storage.SaveChangesAsync();
-
-            query.Options.CheckRights = false;
-            query.Options.AttachActions = false;
-            query.Options.AttachOperations = false;
-
-            entity = await Collection.GetByIdAsync(id, query);
 
             return entity;
         }
@@ -64,12 +54,7 @@ namespace RDD.Application.Controllers
 
             await Storage.SaveChangesAsync();
 
-            query.Options.CheckRights = false;
-
-            var ids = entities.Select(e => e.Id).ToList();
-            var result = await Collection.GetByIdsAsync(ids, query);
-
-            return result;
+            return entities;
         }
 
         public async Task DeleteByIdAsync(TKey id)

--- a/Domain/RDD.Domain.Tests/AppControllerTests.cs
+++ b/Domain/RDD.Domain.Tests/AppControllerTests.cs
@@ -40,8 +40,9 @@ namespace RDD.Domain.Tests
                 var query = new Query<User>();
                 query.Options.CheckRights = false;
 
-                var user = await controller.CreateAsync(PostedData.ParseJson(@"{ ""id"": 3 }"), query);
-                user = await controller.UpdateByIdAsync(3, PostedData.ParseJson(@"{ ""name"": ""newName"" }"), query);
+                await controller.CreateAsync(PostedData.ParseJson(@"{ ""id"": 3 }"), query);
+
+                var user = await controller.UpdateByIdAsync(3, PostedData.ParseJson(@"{ ""name"": ""newName"" }"), query);
 
                 Assert.Equal(3, user.Id);
             }

--- a/Domain/RDD.Domain.Tests/AppControllerTests.cs
+++ b/Domain/RDD.Domain.Tests/AppControllerTests.cs
@@ -1,0 +1,50 @@
+﻿using RDD.Domain.Models.Querying;
+using RDD.Domain.Tests.Models;
+using RDD.Domain.Tests.Templates;
+using RDD.Infra.Storage;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RDD.Domain.Tests
+{
+    public class AppControllerTests : SingleContextTests
+    {
+        [Fact]
+        public async Task PostShouldNotCallGetByIdOnTheCollection()
+        {
+            using (var storage = _newStorage(Guid.NewGuid().ToString()))
+            {
+                var repo = new Repository<User>(storage, _execution, _combinationsHolder);
+                var users = new UsersCollectionWithHardcodedGetById(repo, _execution, _combinationsHolder);
+                var controller = new UsersAppController(storage, users);
+                var query = new Query<User>();
+                query.Options.CheckRights = false;
+
+                var user = await controller.CreateAsync(PostedData.ParseJson(@"{ ""id"": 3 }"), query);
+
+                Assert.Equal(3, user.Id);
+            }
+        }
+
+        [Fact]
+        public async Task PutShouldNotCallGetByIdOnTheCollection()
+        {
+            using (var storage = _newStorage(Guid.NewGuid().ToString()))
+            {
+                var repo = new Repository<User>(storage, _execution, _combinationsHolder);
+                var users = new UsersCollectionWithHardcodedGetById(repo, _execution, _combinationsHolder);
+                var controller = new UsersAppController(storage, users);
+                var query = new Query<User>();
+                query.Options.CheckRights = false;
+
+                var user = await controller.CreateAsync(PostedData.ParseJson(@"{ ""id"": 3 }"), query);
+                user = await controller.UpdateByIdAsync(3, PostedData.ParseJson(@"{ ""name"": ""newName"" }"), query);
+
+                Assert.Equal(3, user.Id);
+            }
+        }
+    }
+}

--- a/Domain/RDD.Domain.Tests/Models/UsersCollectionWithHardcodedGetById.cs
+++ b/Domain/RDD.Domain.Tests/Models/UsersCollectionWithHardcodedGetById.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using RDD.Domain.Models;
+using RDD.Domain.Models.Querying;
+
+namespace RDD.Domain.Tests.Models
+{
+    public class UsersCollectionWithHardcodedGetById : UsersCollection
+    {
+        public UsersCollectionWithHardcodedGetById(IRepository<User> repository, IExecutionContext execution, ICombinationsHolder combinationsHolder)
+            : base(repository, execution, combinationsHolder) { }
+
+        public override Task<User> GetByIdAsync(int id, Query<User> query)
+        {
+            //Only for get, because PUT will always make a GetById( ) to retrieve the entity to update
+            if (query.Verb == Helpers.HttpVerbs.Get)
+            {
+                return Task.FromResult(new User
+                {
+                    Id = 4
+                });
+            }
+
+            return base.GetByIdAsync(id, query);
+        }
+    }
+}


### PR DESCRIPTION
We do not make an extra GetById after a Put or a Post, we directly return the created or modified entity

If the consumer wants to have a fresh version of the entity, it should issue an extra GET request