### PR TITLE
Fix.query watch

### DIFF
--- a/Application/RDD.Application/Controllers/AppController.cs
+++ b/Application/RDD.Application/Controllers/AppController.cs
@@ -34,7 +34,11 @@ namespace RDD.Application.Controllers
         {
             var entity = await Collection.CreateAsync(datas, query);
 
+            query.Watch.Start();
+
             await Storage.SaveChangesAsync();
+
+            query.Watch.Stop();
 
             return entity;
         }
@@ -43,7 +47,11 @@ namespace RDD.Application.Controllers
         {
             var entity = await Collection.UpdateByIdAsync(id, datas, query);
 
+            query.Watch.Start();
+
             await Storage.SaveChangesAsync();
+
+            query.Watch.Stop();
 
             return entity;
         }
@@ -52,23 +60,35 @@ namespace RDD.Application.Controllers
         {
             var entities = await Collection.UpdateByIdsAsync(datasByIds, query);
 
+            query.Watch.Start();
+
             await Storage.SaveChangesAsync();
+
+            query.Watch.Stop();
 
             return entities;
         }
 
-        public async Task DeleteByIdAsync(TKey id)
+        public async Task DeleteByIdAsync(TKey id, Query<TEntity> query)
         {
-            await Collection.DeleteByIdAsync(id);
+            await Collection.DeleteByIdAsync(id, query);
+
+            query.Watch.Start();
 
             await Storage.SaveChangesAsync();
+
+            query.Watch.Stop();
         }
 
-        public async Task DeleteByIdsAsync(IList<TKey> ids)
+        public async Task DeleteByIdsAsync(IList<TKey> ids, Query<TEntity> query)
         {
-            await Collection.DeleteByIdsAsync(ids);
+            await Collection.DeleteByIdsAsync(ids, query);
+
+            query.Watch.Start();
 
             await Storage.SaveChangesAsync();
+
+            query.Watch.Stop();
         }
     }
 }

--- a/Application/RDD.Application/IAppController.cs
+++ b/Application/RDD.Application/IAppController.cs
@@ -13,7 +13,7 @@ namespace RDD.Application
         Task<TEntity> CreateAsync(PostedData datas, Query<TEntity> query);
         Task<TEntity> UpdateByIdAsync(TKey id, PostedData datas, Query<TEntity> query);
         Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, PostedData> datasByIds, Query<TEntity> query);
-        Task DeleteByIdAsync(TKey id);
-        Task DeleteByIdsAsync(IList<TKey> ids);
+        Task DeleteByIdAsync(TKey id, Query<TEntity> query);
+        Task DeleteByIdsAsync(IList<TKey> ids, Query<TEntity> query);
     }
 }

--- a/Domain/RDD.Domain/IRestCollection.cs
+++ b/Domain/RDD.Domain/IRestCollection.cs
@@ -16,7 +16,7 @@ namespace RDD.Domain
         Task<TEntity> UpdateByIdAsync(TKey id, PostedData datas, Query<TEntity> query = null);
         Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, PostedData> datasByIds, Query<TEntity> query = null);
 
-        Task DeleteByIdAsync(TKey id);
-        Task DeleteByIdsAsync(IList<TKey> ids);
+        Task DeleteByIdAsync(TKey id, Query<TEntity> query = null);
+        Task DeleteByIdsAsync(IList<TKey> ids, Query<TEntity> query = null);
     }
 }

--- a/Domain/RDD.Domain/Models/Querying/Query.cs
+++ b/Domain/RDD.Domain/Models/Querying/Query.cs
@@ -41,6 +41,7 @@ namespace RDD.Domain.Models.Querying
         {
             Filters = new List<Filter<TEntity>>(source.Filters);
             OrderBys = new Queue<OrderBy<TEntity>>(source.OrderBys);
+            Options.CheckRights = source.Options.CheckRights;
         }
 
         public virtual Expression<Func<TEntity, bool>> FiltersAsExpression() => new FiltersConvertor<TEntity>().Convert(Filters);

--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -60,11 +60,13 @@ namespace RDD.Domain.Models
         public virtual async Task<TEntity> UpdateByIdAsync(TKey id, PostedData datas, Query<TEntity> query = null)
         {
             query = query ?? new Query<TEntity>();
-            query.Verb = HttpVerbs.Put;
-            query.Options.AttachActions = true;
-            query.Options.AttachOperations = true;
 
-            TEntity entity = await GetByIdAsync(id, query);
+            var getQuery = new Query<TEntity>(query);
+            getQuery.Verb = HttpVerbs.Put;
+            getQuery.Options.AttachActions = true;
+            getQuery.Options.AttachOperations = true;
+
+            TEntity entity = await GetByIdAsync(id, getQuery);
 
             return await UpdateAsync(entity, datas, query);
         }
@@ -92,22 +94,22 @@ namespace RDD.Domain.Models
             return result;
         }
 
-        public virtual async Task DeleteByIdAsync(TKey id)
+        public virtual async Task DeleteByIdAsync(TKey id, Query<TEntity> query)
         {
-            TEntity entity = await GetByIdAsync(id, new Query<TEntity>
-            {
-                Verb = HttpVerbs.Delete
-            });
+            query = query ?? new Query<TEntity>();
+            query.Verb = HttpVerbs.Delete;
+
+            TEntity entity = await GetByIdAsync(id, query);
 
             Repository.Remove(entity);
         }
 
-        public virtual async Task DeleteByIdsAsync(IList<TKey> ids)
+        public virtual async Task DeleteByIdsAsync(IList<TKey> ids, Query<TEntity> query)
         {
-            IEnumerable<TEntity> entities = await GetByIdsAsync(ids, new Query<TEntity>
-            {
-                Verb = HttpVerbs.Delete
-            });
+            query = query ?? new Query<TEntity>();
+            query.Verb = HttpVerbs.Delete;
+
+            IEnumerable<TEntity> entities = await GetByIdsAsync(ids, query);
 
             foreach (TEntity entity in entities)
             {

--- a/Infra/RDD.Infra/Storage/EFRepository.cs
+++ b/Infra/RDD.Infra/Storage/EFRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using RDD.Domain;
+using RDD.Domain.Models.Querying;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,14 +13,26 @@ namespace RDD.Infra.Storage
         public EFRepository(IStorageService storageService, IExecutionContext executionContext, ICombinationsHolder combinationsHolder)
             : base(storageService, executionContext, combinationsHolder) { }
 
-        protected override async Task<int> CountEntities(IQueryable<TEntity> entities)
+        protected override async Task<int> CountEntities(IQueryable<TEntity> entities, Query<TEntity> query)
         {
-            return await entities.CountAsync();
+            query.Watch.Start();
+
+            var result = await entities.CountAsync();
+
+            query.Watch.Stop();
+
+            return result;
         }
 
-        protected override async Task<IEnumerable<TEntity>> EnumerateEntities(IQueryable<TEntity> entities)
+        protected override async Task<IEnumerable<TEntity>> EnumerateEntities(IQueryable<TEntity> entities, Query<TEntity> query)
         {
-            return await entities.ToListAsync();
+            query.Watch.Start();
+
+            var result = await entities.ToListAsync();
+
+            query.Watch.Stop();
+
+            return result;
         }
     }
 }

--- a/Infra/RDD.Infra/Storage/Repository.cs
+++ b/Infra/RDD.Infra/Storage/Repository.cs
@@ -34,11 +34,17 @@ namespace RDD.Infra.Storage
 
             entities = ApplyFilters(entities, query);
 
-            return CountEntities(entities);
+            return CountEntities(entities, query);
         }
-        protected virtual Task<int> CountEntities(IQueryable<TEntity> entities)
+        protected virtual Task<int> CountEntities(IQueryable<TEntity> entities, Query<TEntity> query)
         {
-            return Task.FromResult(entities.Count());
+            query.Watch.Start();
+
+            var result = entities.Count();
+
+            query.Watch.Stop();
+
+            return Task.FromResult(result);
         }
 
         public virtual Task<IEnumerable<TEntity>> EnumerateAsync(Query<TEntity> query)
@@ -55,11 +61,17 @@ namespace RDD.Infra.Storage
             entities = ApplyPage(entities, query);
             entities = ApplyIncludes(entities, query);
 
-            return EnumerateEntities(entities);
+            return EnumerateEntities(entities, query);
         }
-        protected virtual Task<IEnumerable<TEntity>> EnumerateEntities(IQueryable<TEntity> entities)
+        protected virtual Task<IEnumerable<TEntity>> EnumerateEntities(IQueryable<TEntity> entities, Query<TEntity> query)
         {
-            return Task.FromResult<IEnumerable<TEntity>>(entities.ToList());
+            query.Watch.Start();
+
+            var result = entities.ToList();
+
+            query.Watch.Stop();
+
+            return Task.FromResult<IEnumerable<TEntity>>(result);
         }
 
         public virtual Task<IEnumerable<TEntity>> PrepareAsync(IEnumerable<TEntity> entities, Query<TEntity> query)

--- a/Web/RDD.Web/Controllers/WebController.cs
+++ b/Web/RDD.Web/Controllers/WebController.cs
@@ -127,7 +127,9 @@ namespace RDD.Web.Controllers
 
         protected virtual async Task<IActionResult> ProtectedDeleteAsync(TKey id)
         {
-            await AppController.DeleteByIdAsync(id);
+            Query<TEntity> query = Helper.CreateQuery(HttpVerbs.Delete, false);
+
+            await AppController.DeleteByIdAsync(id, query);
 
             return Ok();
         }
@@ -155,7 +157,7 @@ namespace RDD.Web.Controllers
                 throw new BadRequestException(string.Format("DELETE on collection implies that each id be of type : {0}", typeof(TKey).Name));
             }
 
-            await AppController.DeleteByIdsAsync(ids);
+            await AppController.DeleteByIdsAsync(ids, query);
 
             return Ok();
         }


### PR DESCRIPTION
We use Query.Watch to measure the time taken by the SQL layer.

NB : this PR should be later replaced by a stronger way to measure time taken in general, using tools from EF