### PR TITLE
MOD : ApiHelper

### DIFF
--- a/Web/RDD.Web.Tests/ApiHelperTests.cs
+++ b/Web/RDD.Web.Tests/ApiHelperTests.cs
@@ -18,7 +18,7 @@ namespace RDD.Web.Tests
                 HttpContext = new DefaultHttpContext()
             };
             httpContextAccessor.HttpContext.Request.QueryString = QueryString.Create("id", "2");
-            var helper = new ApiHelper<User, int>(new CamelCasePropertyNamesContractResolver(), null, null, httpContextAccessor);
+            var helper = new ApiHelper<User, int>(httpContextAccessor ,null, null);
             var query = helper.CreateQuery(HttpVerbs.Get);
 
             Assert.Single(query.Filters);

--- a/Web/RDD.Web.Tests/WebControllerTests.cs
+++ b/Web/RDD.Web.Tests/WebControllerTests.cs
@@ -26,7 +26,7 @@ namespace RDD.Web.Tests
                 repository.Add(new User { Id = 1 });
                 repository.Add(new AnotherUser { Id = 2 });
 
-                var controller = new IUserWebController(appController, new ApiHelper<IUser, int>(null, null, null, null));
+                var controller = new IUserWebController(appController, new ApiHelper<IUser, int>(null, null, null));
 
                 var results = await controller.GetEnumerableAsync(); //Simplified equivalent to GetAsync()
 

--- a/Web/RDD.Web/Helpers/ApiHelper.cs
+++ b/Web/RDD.Web/Helpers/ApiHelper.cs
@@ -17,17 +17,15 @@ namespace RDD.Web.Helpers
         where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
-        public ApiHelper(IContractResolver jsonResolver, IExecutionContext execution, IEntitySerializer serializer, IHttpContextAccessor httpContextAccessor)
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly QueryFactory<TEntity> _queryFactory = new QueryFactory<TEntity>();
+
+        public ApiHelper(IHttpContextAccessor httpContextAccessor, IExecutionContext execution, IEntitySerializer serializer)
         {
-            _jsonResolver = jsonResolver;
             _httpContextAccessor = httpContextAccessor;
             Execution = execution;
             Serializer = serializer;
         }
-
-        private readonly IContractResolver _jsonResolver;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly QueryFactory<TEntity> _queryFactory = new QueryFactory<TEntity>();
 
         public IExecutionContext Execution { get; }
         public IEntitySerializer Serializer { get; }
@@ -40,8 +38,6 @@ namespace RDD.Web.Helpers
         }
 
         protected virtual ICollection<Expression<Func<TEntity, object>>> IgnoreList() => new HashSet<Expression<Func<TEntity, object>>>();
-
-        private IContractResolver GetJsonResolver() => _jsonResolver;
 
         public List<PostedData> InputObjectsFromIncomingHttpRequest()
         {

--- a/Web/RDD.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/Web/RDD.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -22,7 +22,6 @@ namespace RDD.Web.Helpers
         {
             // register base services
             services.AddScoped(typeof(ApiHelper<,>))
-                .AddSingleton<IContractResolver, CamelCasePropertyNamesContractResolver>()
                 .AddScoped<IEntitySerializer, EntitySerializer>()
                 .AddScoped(typeof(IAppController<,>), typeof(AppController<,>))
                 .AddScoped(typeof(IRestCollection<,>), typeof(RestCollection<,>))


### PR DESCRIPTION
We don't need IContractResolver, it is not used in ApiHelper, and the way camelCase serialization is done can be achieve in client project like the following :

services.AddMvcCore().AddJsonFormatters((settings) =>
{
    settings.ContractResolver = new CamelCasePropertyNamesContractResolver();
});

using AddMvcCore() avoid useless boilerplate (razor & co) and offer a way to register proper camelCase serialization that work with dictionary keys !

see : https://offering.solutions/blog/articles/2017/02/07/difference-between-addmvc-addmvcore/