### PR TITLE
MOD : Field<TEntity> => Field

### DIFF
--- a/Domain/RDD.Domain/Models/Querying/Field.cs
+++ b/Domain/RDD.Domain/Models/Querying/Field.cs
@@ -23,6 +23,15 @@ namespace RDD.Domain.Models.Querying
         public bool HasChild => EntitySelector.HasChild;
         public bool IsEmpty => !HasChild;
         public int Count => EntitySelector.Count;
+
+        protected Field() { }
+        public Field(Type entityType)
+        {
+            EntityType = entityType;
+            EntitySelector = PropertySelector.NewFromType(entityType);
+        }
+
+        public bool Contains<TEntity>(Expression<Func<TEntity, object>> expression) => EntitySelector.Contains(expression);
     }
 
     public class Field<TEntity> : Field
@@ -45,8 +54,6 @@ namespace RDD.Domain.Models.Querying
         {
             return expressions.Select(Add).Aggregate((b1, b2) => b1 && b2);
         }
-
-        public bool Contains(Expression<Func<TEntity, object>> expression) => EntitySelector.Contains(expression);
 
         public bool ContainsEmpty(Expression<Func<TEntity, object>> expression) => EntitySelector.ContainsEmpty(expression);
 

--- a/Domain/RDD.Domain/Models/Querying/Query.cs
+++ b/Domain/RDD.Domain/Models/Querying/Query.cs
@@ -12,8 +12,8 @@ namespace RDD.Domain.Models.Querying
     {
         public Stopwatch Watch { get; }
         public HttpVerbs Verb { get; set; }
-        public Field<TEntity> Fields { get; set; }
-        public Field<ISelection<TEntity>> CollectionFields { get; set; }
+        public Field Fields { get; set; }
+        public Field CollectionFields { get; set; }
         public List<Filter<TEntity>> Filters { get; set; }
         public Queue<OrderBy<TEntity>> OrderBys { get; set; }
         public Page Page { get; set; }

--- a/Web/RDD.Web.Tests/Models/MyValueObject.cs
+++ b/Web/RDD.Web.Tests/Models/MyValueObject.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RDD.Web.Tests.Models
+{
+    public class MyValueObject
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/Web/RDD.Web.Tests/Models/User.cs
+++ b/Web/RDD.Web.Tests/Models/User.cs
@@ -7,6 +7,7 @@ namespace RDD.Web.Tests.Models
     {
         public override int Id { get; set; }
         public override string Name { get; set; }
+        public MyValueObject MyValueObject { get; set; }
 
         IUser ICloneable<IUser>.Clone()
         {

--- a/Web/RDD.Web.Tests/Serialization/PropertySerializerTests.cs
+++ b/Web/RDD.Web.Tests/Serialization/PropertySerializerTests.cs
@@ -2,6 +2,7 @@
 using RDD.Domain.Helpers;
 using RDD.Web.Serialization;
 using RDD.Web.Tests.Models;
+using System.Collections.Generic;
 using Xunit;
 
 namespace RDD.Web.Tests.Serialization
@@ -64,6 +65,35 @@ namespace RDD.Web.Tests.Serialization
             { }
 
             protected override string ApiPrefix => "api/lol";
+        }
+
+        [Fact]
+        public void ValueObject_should_serializeAllProperties()
+        {
+            var user = new User
+            {
+                Id = 1,
+                MyValueObject = new MyValueObject
+                {
+                    Id = 123,
+                    Name = "test"
+                }
+            };
+
+            var httpContextAccessor = new HttpContextAccessor
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+            var urlProvider = new UrlProvider(httpContextAccessor);
+            var serializer = new EntitySerializer(urlProvider);
+
+            var result = serializer.SerializeEntity(user, new PropertySelector<User>(u => u.MyValueObject));
+
+            Assert.True(result.ContainsKey("MyValueObject"));
+
+            var myValueObject = (Dictionary<string, object>)result["MyValueObject"];
+
+            Assert.True(myValueObject.ContainsKey("Id"));
         }
     }
 }

--- a/Web/RDD.Web/IEntitySerializer.cs
+++ b/Web/RDD.Web/IEntitySerializer.cs
@@ -10,8 +10,8 @@ namespace RDD.Web
     {
         Dictionary<string, object> SerializeSelection<TEntity>(ISelection<TEntity> collection, Query<TEntity> query)
             where TEntity : class, IEntityBase;
-        List<Dictionary<string, object>> SerializeEntities<TEntity>(IEnumerable<TEntity> entities, Field<TEntity> fields);
-        Dictionary<string, object> SerializeEntity<TEntity>(TEntity entity, Field<TEntity> fields);
+        List<Dictionary<string, object>> SerializeEntities<TEntity>(IEnumerable<TEntity> entities, Field fields);
+        Dictionary<string, object> SerializeEntity<TEntity>(TEntity entity, Field fields);
 
         List<Dictionary<string, object>> SerializeEntities<TEntity>(IEnumerable<TEntity> entities, PropertySelector fields);
         Dictionary<string, object> SerializeEntity<TEntity>(TEntity entity, PropertySelector fields);

--- a/Web/RDD.Web/Querying/CollectionFieldsParser.cs
+++ b/Web/RDD.Web/Querying/CollectionFieldsParser.cs
@@ -1,13 +1,15 @@
 ﻿using RDD.Domain.Models.Querying;
+using System;
 using System.Collections.Generic;
 
 namespace RDD.Web.Querying
 {
     public class CollectionFieldsParser : FieldsParser
     {
-        public override Field<TEntity> ParseFields<TEntity>(List<string> fields)
+        public override Field ParseFields(Type entityType, List<string> fields)
         {
-            var field = new Field<TEntity>();
+            var field = new Field(entityType);
+
             foreach (var item in fields)
             {
                 if (item.StartsWith("collection."))

--- a/Web/RDD.Web/Querying/FieldsParser.cs
+++ b/Web/RDD.Web/Querying/FieldsParser.cs
@@ -8,7 +8,7 @@ namespace RDD.Web.Querying
 {
     public class FieldsParser
     {
-        public Field<TEntity> ParseFields<TEntity>(Dictionary<string, string> parameters, bool isCollectionCall)
+        public Field ParseFields<TEntity>(Dictionary<string, string> parameters, bool isCollectionCall)
         {
             if (parameters.ContainsKey(Reserved.fields.ToString()))
             {
@@ -22,23 +22,33 @@ namespace RDD.Web.Querying
             return new Field<TEntity>();
         }
 
-        public Field<TEntity> ParseFields<TEntity>(string fields)
+        public Field ParseFields<TEntity>(string fields)
         {
             var expandedFields = new FieldExpansionHelper().Expand(fields);
 
             return ParseFields<TEntity>(expandedFields);
         }
 
-        public Field<TEntity> ParseAllProperties<TEntity>()
+        public Field ParseAllProperties<TEntity>()
         {
-            var fields = typeof(TEntity).GetProperties().Select(p => p.Name).ToList();
-
-            return ParseFields<TEntity>(fields);
+            return ParseAllProperties(typeof(TEntity));
         }
 
-        public virtual Field<TEntity> ParseFields<TEntity>(List<string> fields)
+        public Field ParseAllProperties(Type entityType)
         {
-            var field = new Field<TEntity>();
+            var fields = entityType.GetProperties().Select(p => p.Name).ToList();
+
+            return ParseFields(entityType, fields);
+        }
+
+        public Field ParseFields<TEntity>(List<string> fields)
+        {
+            return ParseFields(typeof(TEntity), fields);
+        }
+        public virtual Field ParseFields(Type entityType, List<string> fields)
+        {
+            var field = new Field(entityType);
+
             foreach (var item in fields)
             {
                 if (!item.StartsWith("collection."))

--- a/Web/RDD.Web/Querying/OptionsParser.cs
+++ b/Web/RDD.Web/Querying/OptionsParser.cs
@@ -7,12 +7,12 @@ namespace RDD.Web.Querying
     public class OptionsParser<TEntity>
         where TEntity : class, IEntityBase
     {
-        public Options Parse(Dictionary<string, string> parameters, Field<TEntity> fields, Field<ISelection<TEntity>> collectionFields)
+        public Options Parse(Dictionary<string, string> parameters, Field fields, Field collectionFields)
         {
             var options = new Options();
 
             //Si les fields demandent des propriétés sur la collection
-            if (collectionFields.Contains(c => c.Count))
+            if (collectionFields.Contains<ISelection<TEntity>>(c => c.Count))
             {
                 options.NeedCount = true;
 

--- a/Web/RDD.Web/Serialization/EntitySerializer.cs
+++ b/Web/RDD.Web/Serialization/EntitySerializer.cs
@@ -103,7 +103,7 @@ namespace RDD.Web.Serialization
             return result;
         }
 
-        public Dictionary<string, object> SerializeEntity<TEntity>(TEntity entity, Field<TEntity> fields)
+        public Dictionary<string, object> SerializeEntity<TEntity>(TEntity entity, Field fields)
         {
             return fields == null ? new Dictionary<string, object>() : SerializeEntity(entity, fields.EntitySelector);
         }
@@ -111,7 +111,7 @@ namespace RDD.Web.Serialization
         {
             return SerializeEntities(new List<TEntity> { entity }, fields).FirstOrDefault();
         }
-        public List<Dictionary<string, object>> SerializeEntities<TEntity>(IEnumerable<TEntity> entities, Field<TEntity> fields)
+        public List<Dictionary<string, object>> SerializeEntities<TEntity>(IEnumerable<TEntity> entities, Field fields)
         {
             return fields == null ? new List<Dictionary<string, object>>() : SerializeEntities(entities, fields.EntitySelector);
         }
@@ -130,7 +130,9 @@ namespace RDD.Web.Serialization
                         //Si c'est un entitybase mais qu'on ne demande aucun field particulier, on va renvoyer id, name, url
                         if (!fields.HasChild)
                         {
-                            if (entity.GetType().IsSubclassOfInterface(typeof(IEntityBase)))
+                            var entityType = entity.GetType();
+
+                            if (entityType.IsSubclassOfInterface(typeof(IEntityBase)))
                             {
                                 fields.Parse("id");
                                 fields.Parse("name");
@@ -138,7 +140,7 @@ namespace RDD.Web.Serialization
                             }
                             else
                             {
-                                fields = new FieldsParser().ParseAllProperties<TEntity>().EntitySelector;
+                                fields = new FieldsParser().ParseAllProperties(entityType).EntitySelector;
                             }
                         }
 


### PR DESCRIPTION
Field can be used for under-classes or objects, so we don't want to keep TEntity when TEntity does not refer to the root API class

FIX : under-classes that are value objects where not serialized at all. One had to provide precise fields in order for under-properties to be serialized