### PR TITLE
FIX : Neasted filter

### DIFF
--- a/Domain/RDD.Domain.Tests/CollectionMethodsTests.cs
+++ b/Domain/RDD.Domain.Tests/CollectionMethodsTests.cs
@@ -196,7 +196,7 @@ namespace RDD.Domain.Tests
 
                 await storage.SaveChangesAsync();
 
-                query.Filters.Add(new Filter<User>(new PropertySelector<User>(u => u.TwitterUri), FilterOperand.Equals, new List<Uri>() { new Uri("https://twitter.com") }));
+                query.Filters.Add(new Filter<User>(new PropertySelector<User>(u => u.TwitterUri.Host), FilterOperand.Equals, new List<string>() { "twitter.com" }));
 
                 var results = await users.GetAsync(query);
 

--- a/Domain/RDD.Domain.Tests/PropertySelectorTests.cs
+++ b/Domain/RDD.Domain.Tests/PropertySelectorTests.cs
@@ -13,5 +13,14 @@ namespace RDD.Domain.Tests
             var selector = new CollectionPropertySelector<User>();
             selector.Parse(field);
         }
+
+        [Fact]
+        public void NeastedSelector_should_work()
+        {
+            var selector = new PropertySelector<User>(u => u.TwitterUri.Host);
+
+            Assert.True(selector.Contains(u => u.TwitterUri));
+            Assert.True(selector.Contains(u => u.TwitterUri.Host));
+        }
     }
 }

--- a/Domain/RDD.Domain/Helpers/PropertySelector.cs
+++ b/Domain/RDD.Domain/Helpers/PropertySelector.cs
@@ -44,6 +44,27 @@ namespace RDD.Domain.Helpers
             }
         }
 
+        public string Path
+        {
+            get
+            {
+                //Root
+                if (Lambda == null)
+                {
+                    return Children.ElementAt(0).Path;
+                }
+
+                //Intermediate
+                if (HasChild)
+                {
+                    return $"{Name}.{Children.ElementAt(0).Path}";
+                }
+
+                //Leaf
+                return Name;
+            }
+        }
+
         public string Subject { get; set; }
 
         public int LeafNumber

--- a/Domain/RDD.Domain/Models/Querying/Convertors/FiltersConvertor.cs
+++ b/Domain/RDD.Domain/Models/Querying/Convertors/FiltersConvertor.cs
@@ -37,13 +37,13 @@ namespace RDD.Domain.Models.Querying.Convertors
 
         private Expression<Func<TEntity, bool>> ToEntityExpression(Filter<TEntity> filter, IList values)
         {
-            PropertySelector property = filter.Property.Children.ElementAt(0);
+            var propertyPath = filter.Property.Path;
 
             switch (filter.Operand)
             {
                 case FilterOperand.Equals:
                     {
-                        return _predicateService.BuildBinaryExpression(filter.Operand, property.Name, values);
+                        return _predicateService.BuildBinaryExpression(filter.Operand, propertyPath, values);
                     }
                 case FilterOperand.Between:
                 case FilterOperand.GreaterThan:
@@ -53,19 +53,19 @@ namespace RDD.Domain.Models.Querying.Convertors
                 case FilterOperand.Since:
                 case FilterOperand.Until:
                     {
-                        return _predicateService.OrFactory<TEntity, object>(value => _predicateService.BuildBinaryExpression(filter.Operand, property.Name, value), values);
+                        return _predicateService.OrFactory<TEntity, object>(value => _predicateService.BuildBinaryExpression(filter.Operand, propertyPath, value), values);
                     }
                 case FilterOperand.NotEqual:
                     {
-                        return _predicateService.AndFactory<TEntity, object>(value => _predicateService.BuildBinaryExpression(filter.Operand, property.Name, value), values);
+                        return _predicateService.AndFactory<TEntity, object>(value => _predicateService.BuildBinaryExpression(filter.Operand, propertyPath, value), values);
                     }
                 case FilterOperand.Starts:
                     {
-                        return _predicateService.OrFactory<TEntity, string>(value => _predicateService.BuildStartsExpression(property.Name, value), values);
+                        return _predicateService.OrFactory<TEntity, string>(value => _predicateService.BuildStartsExpression(propertyPath, value), values);
                     }
                 case FilterOperand.Like:
                     {
-                        return _predicateService.OrFactory<TEntity, string>(value => _predicateService.BuildLikeExpression(property.Name, value), values);
+                        return _predicateService.OrFactory<TEntity, string>(value => _predicateService.BuildLikeExpression(propertyPath, value), values);
                     }
             }
 


### PR DESCRIPTION
Les filtres de premier niveau fonctionnaient, mais pas un filtre à 2+ niveaux :

u => u.TwitterUri OK
u => u.TwitterUri.Host KO

Désormais on supporte N niveaux