### PR TITLE
FIX : Guid in where query clause

### DIFF
--- a/Domain/RDD.Domain.Tests/GuidHelperTests.cs
+++ b/Domain/RDD.Domain.Tests/GuidHelperTests.cs
@@ -1,0 +1,35 @@
+﻿using RDD.Domain.Helpers;
+using RDD.Domain.Models.Querying;
+using RDD.Domain.Tests.Models;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace RDD.Domain.Tests
+{
+    public class GuidHelperTests
+    {
+        private GuidHelper _helper;
+
+        public GuidHelperTests()
+        {
+            _helper = new GuidHelper();
+        }
+
+        [Theory]
+        [InlineData("aabbccdd-eeff", "Incomplete Guid with dashes")]
+        [InlineData("aabbccdd-eeff-1111-2222-333333333333", "Full Guid")]
+        [InlineData("aabbccddeeff", "Incomplete Guid without dash")]
+        public void InterpreteStringAsGuid_WHEN_WellFormedStringGuid(string input, string label)
+        {
+            try
+            {
+                _helper.Complete(input);
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Fail for label: {label}", e);
+            }
+        }
+    }
+}

--- a/Domain/RDD.Domain.Tests/GuidHelperTests.cs
+++ b/Domain/RDD.Domain.Tests/GuidHelperTests.cs
@@ -22,14 +22,7 @@ namespace RDD.Domain.Tests
         [InlineData("aabbccddeeff", "Incomplete Guid without dash")]
         public void InterpreteStringAsGuid_WHEN_WellFormedStringGuid(string input, string label)
         {
-            try
-            {
-                _helper.Complete(input);
-            }
-            catch (Exception e)
-            {
-                throw new Exception($"Fail for label: {label}", e);
-            }
+            _helper.Complete(input);
         }
     }
 }

--- a/Domain/RDD.Domain.Tests/GuidHelperTests.cs
+++ b/Domain/RDD.Domain.Tests/GuidHelperTests.cs
@@ -9,7 +9,7 @@ namespace RDD.Domain.Tests
 {
     public class GuidHelperTests
     {
-        private GuidHelper _helper;
+        private readonly GuidHelper _helper;
 
         public GuidHelperTests()
         {

--- a/Domain/RDD.Domain.Tests/Models/User.cs
+++ b/Domain/RDD.Domain.Tests/Models/User.cs
@@ -13,6 +13,7 @@ namespace RDD.Domain.Tests.Models
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }
         public Department Department { get; set; }
+        public Guid PictureId { get; set; }
 
         public static IEnumerable<User> GetManyRandomUsers(int howMuch)
         {

--- a/Domain/RDD.Domain/Helpers/GuidHelper.cs
+++ b/Domain/RDD.Domain/Helpers/GuidHelper.cs
@@ -1,0 +1,20 @@
+﻿using NExtends.Primitives.Strings;
+using System;
+
+namespace RDD.Domain.Helpers
+{
+    public class GuidHelper
+    {
+        public Guid Complete(string value)
+        {
+            //value : aabbccdd-eeff for instance
+            value = value.Replace("-", "");
+
+            var emptyGuid = "0".Repeat(32);
+
+            var result = emptyGuid.Replace(emptyGuid.Substring(0, value.Length), value);
+
+            return new Guid(result);
+        }
+    }
+}

--- a/Domain/RDD.Domain/Models/Querying/SerializationService.cs
+++ b/Domain/RDD.Domain/Models/Querying/SerializationService.cs
@@ -1,6 +1,7 @@
 ﻿using NExtends.Primitives.DateTimes;
 using NExtends.Primitives.Strings;
 using NExtends.Primitives.Types;
+using RDD.Domain.Helpers;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -102,6 +103,12 @@ namespace RDD.Domain.Models.Querying
                     culture = CultureInfo.InvariantCulture;
                 }
 
+                if (correctPropertyType == typeof(Guid))
+                {
+                    //In case stringValue is incomplete (ie: aabbccdd-eeff in a like clause)
+                    //We feed it with 0-based Guid
+                    return new GuidHelper().Complete(stringValue);
+                }
 
                 return realStringValue.ChangeType(correctPropertyType, culture);
             }

--- a/Web/RDD.Web.Tests/FilterParserTests.cs
+++ b/Web/RDD.Web.Tests/FilterParserTests.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json.Serialization;
+using RDD.Domain.Helpers;
+using RDD.Web.Helpers;
+using RDD.Web.Tests.Models;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace RDD.Web.Tests
+{
+    public class FilterParserTests
+    {
+        [Fact]
+        public void LikeOperationOnGuidShouldWork()
+        {
+            var httpContextAccessor = new HttpContextAccessor
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+            httpContextAccessor.HttpContext.Request.QueryString = QueryString.Create("pictureId", "like,aabbccdd-eeff");
+            var helper = new ApiHelper<User, int>(httpContextAccessor ,null, null);
+            var query = helper.CreateQuery(HttpVerbs.Get);
+        }
+    }
+}

--- a/Web/RDD.Web.Tests/FilterParserTests.cs
+++ b/Web/RDD.Web.Tests/FilterParserTests.cs
@@ -19,7 +19,8 @@ namespace RDD.Web.Tests
             };
             httpContextAccessor.HttpContext.Request.QueryString = QueryString.Create("pictureId", "like,aabbccdd-eeff");
             var helper = new ApiHelper<User, int>(httpContextAccessor ,null, null);
-            var query = helper.CreateQuery(HttpVerbs.Get);
+
+            helper.CreateQuery(HttpVerbs.Get);
         }
     }
 }

--- a/Web/RDD.Web.Tests/Models/User.cs
+++ b/Web/RDD.Web.Tests/Models/User.cs
@@ -12,6 +12,7 @@ namespace RDD.Web.Tests.Models
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }
         public Department Department { get; set; }
+        public Guid PictureId { get; set; }
 
         IUser ICloneable<IUser>.Clone()
         {


### PR DESCRIPTION
`where` operation was not functional on Guid property type

Now you can sent a complete or incomplete Guid, with or without dashes