### PR TITLE
REF : .net Core 2.0 -> 2.1.Rc

### DIFF
--- a/Domain/RDD.Domain.Tests/RDD.Domain.Tests.csproj
+++ b/Domain/RDD.Domain.Tests/RDD.Domain.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.0-rc1-final" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Domain/RDD.Domain/RDD.Domain.csproj
+++ b/Domain/RDD.Domain/RDD.Domain.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="1.1.11" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.0.0" />
+    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="1.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.1.0-rc1-final" />
     <PackageReference Include="NExtends" Version="2.1.0" />
   </ItemGroup>
 

--- a/Infra/RDD.Infra/RDD.Infra.csproj
+++ b/Infra/RDD.Infra/RDD.Infra.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0-rc1-final" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Web/RDD.Web.Tests/RDD.Web.Tests.csproj
+++ b/Web/RDD.Web.Tests/RDD.Web.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.0-rc1-final" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/Web/RDD.Web/RDD.Web.csproj
+++ b/Web/RDD.Web/RDD.Web.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Inflector.NetStandard" Version="1.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.0-rc1-final" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Je suis tombé sur un bug/limitation de efcore 2.0, apparemment fixé en 2.1

la rc est prod ready, d'après l'annonce https://blogs.msdn.microsoft.com/dotnet/2018/05/07/announcing-entity-framework-core-2-1-rc-1/

faudra simplement switcher quand la 2.1 ne sera plus en rc