### PR TITLE
Remove GetByIdsAsync

### DIFF
--- a/Domain/RDD.Domain/IReadOnlyRestCollection.cs
+++ b/Domain/RDD.Domain/IReadOnlyRestCollection.cs
@@ -13,6 +13,5 @@ namespace RDD.Domain
         Task<IEnumerable<TEntity>> GetAllAsync();
         Task<bool> AnyAsync(Query<TEntity> query);
         Task<TEntity> GetByIdAsync(TKey id, Query<TEntity> query);
-        Task<IEnumerable<TEntity>> GetByIdsAsync(IList<TKey> ids, Query<TEntity> query);
     }
 }

--- a/Domain/RDD.Domain/Models/Querying/ExpressionQuery.cs
+++ b/Domain/RDD.Domain/Models/Querying/ExpressionQuery.cs
@@ -15,6 +15,7 @@ namespace RDD.Domain.Models.Querying
         public ExpressionQuery(Query<TEntity> source, Expression<Func<TEntity, bool>> filters)
             : this(filters)
         {
+            Verb = source.Verb;
             Fields = source.Fields;
             OrderBys = source.OrderBys;
             Page = source.Page;

--- a/Domain/RDD.Domain/Models/ReadOnlyRestCollection.cs
+++ b/Domain/RDD.Domain/Models/ReadOnlyRestCollection.cs
@@ -92,25 +92,14 @@ namespace RDD.Domain.Models
         /// <returns></returns>
         public virtual async Task<TEntity> GetByIdAsync(TKey id, Query<TEntity> query)
         {
-            TEntity result = (await GetByIdsAsync(new List<TKey>
-            {
-                id
-            }, query)).FirstOrDefault();
+            TEntity result = (await GetAsync(new ExpressionQuery<TEntity>(query, e => e.Id.Equals(id)))).Items.FirstOrDefault();
 
             if (result == null)
             {
-                //NB : si verb == PUT alors l'exception UnAuthorized sera levée lors du GetByIds
                 throw new NotFoundException(string.Format("Resource with ID {0} not found", id));
             }
 
             return result;
-        }
-
-        public virtual async Task<IEnumerable<TEntity>> GetByIdsAsync(IList<TKey> ids, Query<TEntity> query)
-        {
-            query.Filters.Add(new Filter<TEntity>(new PropertySelector<TEntity>(e => e.Id), FilterOperand.Equals, (IList) ids));
-
-            return (await GetAsync(query)).Items;
         }
 
         protected void AttachOperationsToEntity(TEntity entity)
@@ -208,24 +197,7 @@ namespace RDD.Domain.Models
             }
         }
 
-        public async Task<IEnumerable<TEntity>> TryGetByIdsAsync(IEnumerable<object> id)
-        {
-            try
-            {
-                return await GetByIdsAsync(new List<TKey>(id.Cast<TKey>()));
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
         public Task<TEntity> GetByIdAsync(TKey id, HttpVerbs verb = HttpVerbs.Get) => GetByIdAsync(id, new Query<TEntity>
-        {
-            Verb = verb
-        });
-
-        public async Task<IEnumerable<TEntity>> GetByIdsAsync(IList<TKey> ids, HttpVerbs verb = HttpVerbs.Get) => await GetByIdsAsync(ids, new Query<TEntity>
         {
             Verb = verb
         });

--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -76,8 +76,6 @@ namespace RDD.Domain.Models
             query.Options.AttachActions = true;
             query.Options.AttachOperations = true;
 
-            List<TKey> ids = datasByIds.Keys.ToList();
-
             var result = new HashSet<TEntity>();
 
             foreach (KeyValuePair<TKey, PostedData> kvp in datasByIds)

--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -77,13 +77,12 @@ namespace RDD.Domain.Models
             query.Options.AttachOperations = true;
 
             List<TKey> ids = datasByIds.Keys.ToList();
-            Dictionary<TKey, TEntity> entities = (await GetByIdsAsync(ids, query)).ToDictionary(el => el.Id, el => el);
 
             var result = new HashSet<TEntity>();
 
             foreach (KeyValuePair<TKey, PostedData> kvp in datasByIds)
             {
-                TEntity entity = entities[kvp.Key];
+                var entity = await GetByIdAsync(kvp.Key, query);
                 entity = await UpdateAsync(entity, kvp.Value, query);
 
                 result.Add(entity);
@@ -104,13 +103,10 @@ namespace RDD.Domain.Models
 
         public virtual async Task DeleteByIdsAsync(IList<TKey> ids)
         {
-            IEnumerable<TEntity> entities = await GetByIdsAsync(ids, new Query<TEntity>
+            foreach (var id in ids)
             {
-                Verb = HttpVerbs.Delete
-            });
+                var entity = await GetByIdAsync(id, HttpVerbs.Delete);
 
-            foreach (TEntity entity in entities)
-            {
                 Repository.Remove(entity);
             }
         }


### PR DESCRIPTION
On vire le GetByIds, mais on conserve les UpdateByIdsAsync et DeleteByIdsAsync car ceux là peuvent avoir du sens depuis un appel front qui ferait du traitement de masse.

Resolves https://github.com/LuccaSA/RestDrivenDomain/issues/121