### PR TITLE
MOD : RightExpressionHelper -> RIghtExpressionHelper<T>

### DIFF
--- a/Domain/RDD.Domain.Mocks/RightsServiceMock.cs
+++ b/Domain/RDD.Domain.Mocks/RightsServiceMock.cs
@@ -5,8 +5,9 @@ using System.Linq.Expressions;
 
 namespace RDD.Domain.Mocks
 {
-    public class RightsServiceMock : IRightExpressionsHelper
+    public class RightsServiceMock<T> : IRightExpressionsHelper<T>
+        where T : class
     {
-        public Expression<Func<T, bool>> GetFilter<T>(Query<T> query) where T : class => t => true;
+        public Expression<Func<T, bool>> GetFilter(Query<T> query) => t => true;
     }
 }

--- a/Domain/RDD.Domain.Tests/AbstractEntityTests.cs
+++ b/Domain/RDD.Domain.Tests/AbstractEntityTests.cs
@@ -25,7 +25,7 @@ namespace RDD.Domain.Tests
         [Fact]
         public async void NonAbstractCollection_SHOULD_return_all_entities_WHEN_GetAll_is_called()
         {
-            var rightsService = new RightsServiceMock();
+            var rightsService = new RightsServiceMock<ConcreteClassThree>();
             var storage = new InMemoryStorageService();
             var repo = new OpenRepository<ConcreteClassThree>(storage, rightsService);
 
@@ -42,7 +42,7 @@ namespace RDD.Domain.Tests
         [Fact]
         public async void AbstractCollection_SHOULD_return_all_entities_WHEN_GetAll_is_called()
         {
-            var rightsService = new RightsServiceMock();
+            var rightsService = new RightsServiceMock<AbstractClass>();
             var storage = new InMemoryStorageService();
             var repo = new OpenRepository<AbstractClass>(storage, rightsService);
 

--- a/Domain/RDD.Domain.Tests/CollectionMethodsTests.cs
+++ b/Domain/RDD.Domain.Tests/CollectionMethodsTests.cs
@@ -67,7 +67,7 @@ namespace RDD.Domain.Tests
                         new Combination { Operation = new Operation { Id = 1 }, Subject = typeof(User), Verb = HttpVerbs.Post },
                         new Combination { Operation = new Operation { Id = 1 }, Subject = typeof(User), Verb = HttpVerbs.Put }
                     });
-                var rightService = new RightExpressionsHelper(new WebService { Id = 1, AppOperations = new HashSet<int> { 1 } }, mock.Object);
+                var rightService = new RightExpressionsHelper<User>(new WebService { Id = 1, AppOperations = new HashSet<int> { 1 } }, mock.Object);
 
                 var user = new User { Id = 3 };
                 var repo = new Repository<User>(storage, rightService);
@@ -110,7 +110,7 @@ namespace RDD.Domain.Tests
         {
             using (var storage = _newStorage(Guid.NewGuid().ToString()))
             {
-                var repo = new Repository<UserWithParameters>(storage, _rightsService);
+                var repo = new Repository<UserWithParameters>(storage, new RightsServiceMock<UserWithParameters>());
                 var users = new UsersCollectionWithParameters(repo, _patcherProvider, new InstanciatorImplementation());
                 var query = new Query<UserWithParameters>();
                 query.Options.CheckRights = false;

--- a/Domain/RDD.Domain.Tests/Models/OpenRepository.cs
+++ b/Domain/RDD.Domain.Tests/Models/OpenRepository.cs
@@ -9,7 +9,7 @@ namespace RDD.Domain.Tests.Models
     public class OpenRepository<TEntity> : Repository<TEntity>
         where TEntity : class
     {
-        public OpenRepository(IStorageService storageService, IRightExpressionsHelper rightsService)
+        public OpenRepository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightsService)
         : base(storageService, rightsService) { }
 
         protected override IQueryable<TEntity> ApplyRights(IQueryable<TEntity> entities, Query<TEntity> query)

--- a/Domain/RDD.Domain.Tests/Templates/SingleContextTests.cs
+++ b/Domain/RDD.Domain.Tests/Templates/SingleContextTests.cs
@@ -13,14 +13,14 @@ namespace RDD.Domain.Tests.Templates
     public class SingleContextTests
     {
         protected Func<string, IStorageService> _newStorage;
-        protected IRightExpressionsHelper _rightsService;
+        protected IRightExpressionsHelper<User> _rightsService;
         protected IPatcherProvider _patcherProvider;
         protected IInstanciator<User> Instanciator { get; set; }
 
         public SingleContextTests()
         {
             _newStorage = name => new EFStorageService(new DataContext(GetOptions(name)));
-            _rightsService = new RightsServiceMock();
+            _rightsService = new RightsServiceMock<User>();
             _patcherProvider = new PatcherProvider();
             Instanciator = new DefaultInstanciator<User>();
         }

--- a/Domain/RDD.Domain/Rights/IRightExpressionsHelper.cs
+++ b/Domain/RDD.Domain/Rights/IRightExpressionsHelper.cs
@@ -4,8 +4,9 @@ using System.Linq.Expressions;
 
 namespace RDD.Domain.Rights
 {
-    public interface IRightExpressionsHelper
+    public interface IRightExpressionsHelper<T>
+         where T : class
     {
-        Expression<Func<T, bool>> GetFilter<T>(Query<T> query) where T : class;
+        Expression<Func<T, bool>> GetFilter(Query<T> query);
     }
 }

--- a/Domain/RDD.Domain/Rights/RightExpressionsHelper.cs
+++ b/Domain/RDD.Domain/Rights/RightExpressionsHelper.cs
@@ -8,7 +8,8 @@ using System.Linq.Expressions;
 
 namespace RDD.Domain.Rights
 {
-    public class RightExpressionsHelper : IRightExpressionsHelper
+    public class RightExpressionsHelper<T> : IRightExpressionsHelper<T>
+         where T : class
     {
         protected IPrincipal Principal { get; set; }
         protected ICombinationsHolder CombinationsHolder { get; set; }
@@ -19,14 +20,14 @@ namespace RDD.Domain.Rights
             CombinationsHolder = combinationsHolder ?? throw new ArgumentNullException(nameof(combinationsHolder));
         }
 
-        public virtual Expression<Func<T, bool>> GetFilter<T>(Query<T> query) where T : class
+        public virtual Expression<Func<T, bool>> GetFilter(Query<T> query)
         {
             if (Principal == null)
             {
                 throw new ForbiddenException("Anonymous query is forbidden");
             }
 
-            var operationIds = GetOperationIds<T>(query.Verb);
+            var operationIds = GetOperationIds(query.Verb);
             if (!operationIds.Any())
             {
                 throw new UnreachableEntityException(typeof(T));
@@ -35,7 +36,7 @@ namespace RDD.Domain.Rights
             return t => true;
         }
 
-        public virtual HashSet<int> GetOperationIds<T>(HttpVerbs verb)
+        public virtual HashSet<int> GetOperationIds(HttpVerbs verb)
         {
             var combinations = CombinationsHolder.Combinations.Where(c => c.Subject == typeof(T) && c.Verb.HasVerb(verb));
             return new HashSet<int>(combinations.Select(c => c.Operation.Id));

--- a/Infra/RDD.Infra/Storage/ReadOnlyRepository.cs
+++ b/Infra/RDD.Infra/Storage/ReadOnlyRepository.cs
@@ -12,9 +12,9 @@ namespace RDD.Infra.Storage
         where TEntity : class
     {
         protected IStorageService StorageService { get; set; }
-        protected IRightExpressionsHelper RightExpressionsHelper { get; set; }
+        protected IRightExpressionsHelper<TEntity> RightExpressionsHelper { get; set; }
 
-        public ReadOnlyRepository(IStorageService storageService, IRightExpressionsHelper rightExpressionsHelper)
+        public ReadOnlyRepository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightExpressionsHelper)
         {
             StorageService = storageService;
             RightExpressionsHelper = rightExpressionsHelper;

--- a/Infra/RDD.Infra/Storage/Repository.cs
+++ b/Infra/RDD.Infra/Storage/Repository.cs
@@ -7,7 +7,7 @@ namespace RDD.Infra.Storage
     public class Repository<TEntity> : ReadOnlyRepository<TEntity>, IRepository<TEntity>
         where TEntity : class
     {
-        public Repository(IStorageService storageService, IRightExpressionsHelper rightExpressionsHelper)
+        public Repository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightExpressionsHelper)
             : base(storageService, rightExpressionsHelper) { }
 
         public virtual void Add(TEntity entity)

--- a/Web/RDD.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/Web/RDD.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -50,7 +50,7 @@ namespace RDD.Web.Helpers
             where TCombinationsHolder : class, ICombinationsHolder
             where TPrincipal : class, IPrincipal
         {
-            services.TryAddScoped<IRightExpressionsHelper, RightExpressionsHelper>();
+            services.TryAddScoped(typeof(IRightExpressionsHelper<>), typeof(RightExpressionsHelper<>));
             services.TryAddScoped<IPrincipal, TPrincipal>();
             services.TryAddScoped<ICombinationsHolder, TCombinationsHolder>();
             return services;


### PR DESCRIPTION
Pour un projet même de taille moyenne (comme poplee talent), il est illusoire d'espérer avec une classe unique capable de gérer tous les filtres de droits.
En mettant le type dans l'interface, les overrides seront plus simples à gérer