### PR TITLE
MOD : pas de paging sur les requêtes internes + getAll/CountAll

### DIFF
--- a/Domain/RDD.Domain.Tests/AbstractEntityTests.cs
+++ b/Domain/RDD.Domain.Tests/AbstractEntityTests.cs
@@ -1,5 +1,6 @@
 ﻿using RDD.Domain.Mocks;
 using RDD.Domain.Models;
+using RDD.Domain.Models.Querying;
 using RDD.Domain.Rights;
 using RDD.Domain.Tests.Models;
 using RDD.Infra.Storage;
@@ -34,9 +35,9 @@ namespace RDD.Domain.Tests
 
             var collection = new ConcreteClassThreeCollection(repo);
 
-            var result = await collection.GetAllAsync();
+            var result = await collection.GetAsync(new Query<ConcreteClassThree>());
 
-            Assert.Equal(2, result.Count());
+            Assert.Equal(2, result.Items.Count());
         }
 
         [Fact]
@@ -52,9 +53,9 @@ namespace RDD.Domain.Tests
 
             var collection = new AbstractClassCollection(repo);
 
-            var result = await collection.GetAllAsync();
+            var result = await collection.GetAsync(new Query<AbstractClass>());
 
-            Assert.Equal(3, result.Count());
+            Assert.Equal(3, result.Items.Count());
         }
     }
 }

--- a/Domain/RDD.Domain/IReadOnlyRestCollection.cs
+++ b/Domain/RDD.Domain/IReadOnlyRestCollection.cs
@@ -10,7 +10,6 @@ namespace RDD.Domain
         where TKey : IEquatable<TKey>
     {
         Task<ISelection<TEntity>> GetAsync(Query<TEntity> query);
-        Task<IEnumerable<TEntity>> GetAllAsync();
         Task<bool> AnyAsync(Query<TEntity> query);
         Task<TEntity> GetByIdAsync(TKey id, Query<TEntity> query);
     }

--- a/Domain/RDD.Domain/Models/Querying/Page.cs
+++ b/Domain/RDD.Domain/Models/Querying/Page.cs
@@ -1,12 +1,13 @@
 ﻿using RDD.Domain.Exceptions;
-using System.Net;
 
 namespace RDD.Domain.Models.Querying
 {
     public class Page
     {
         protected const int MAX_LIMIT = 1000;
+
         public static Page Default => new Page(0, 10);
+        public static Page Unlimited => new Page(0, int.MaxValue, int.MaxValue);
 
         public int Offset { get; }
         public int Limit { get; }

--- a/Domain/RDD.Domain/Models/Querying/Page.cs
+++ b/Domain/RDD.Domain/Models/Querying/Page.cs
@@ -7,7 +7,7 @@ namespace RDD.Domain.Models.Querying
         protected const int MAX_LIMIT = 1000;
 
         public static Page Default => new Page(0, 10);
-        public static Page Unlimited => new Page(0, int.MaxValue, int.MaxValue);
+        public static Page Max => new Page(0, MAX_LIMIT);
 
         public int Offset { get; }
         public int Limit { get; }

--- a/Domain/RDD.Domain/Models/Querying/Query.cs
+++ b/Domain/RDD.Domain/Models/Querying/Query.cs
@@ -35,7 +35,7 @@ namespace RDD.Domain.Models.Querying
             : this()
         {
             Filter = new Filter<TEntity>(filter);
-            Page = Page.Unlimited;
+            Page = Page.Max;
         }
 
         public Query(Query<TEntity> source)
@@ -52,7 +52,7 @@ namespace RDD.Domain.Models.Querying
         public Query(Query<TEntity> source, Expression<Func<TEntity, bool>> filter)
             : this(source)
         {
-            Page = Page.Unlimited;
+            Page = Page.Max;
             Filter = new Filter<TEntity>(filter);
         }
     }

--- a/Domain/RDD.Domain/Models/Querying/Query.cs
+++ b/Domain/RDD.Domain/Models/Querying/Query.cs
@@ -30,11 +30,14 @@ namespace RDD.Domain.Models.Querying
             Options = new Options();
             Page = Page.Default;
         }
+
         public Query(Expression<Func<TEntity, bool>> filter)
             : this()
         {
             Filter = new Filter<TEntity>(filter);
+            Page = Page.Unlimited;
         }
+
         public Query(Query<TEntity> source)
             : this()
         {
@@ -45,9 +48,11 @@ namespace RDD.Domain.Models.Querying
             Page = source.Page;
             Options = source.Options;
         }
+
         public Query(Query<TEntity> source, Expression<Func<TEntity, bool>> filter)
             : this(source)
         {
+            Page = Page.Unlimited;
             Filter = new Filter<TEntity>(filter);
         }
     }

--- a/Domain/RDD.Domain/Models/ReadOnlyRestCollection.cs
+++ b/Domain/RDD.Domain/Models/ReadOnlyRestCollection.cs
@@ -27,7 +27,7 @@ namespace RDD.Domain.Models
             return (await GetAsync(query)).Count > 0;
         }
 
-        public async Task<IEnumerable<TEntity>> GetAllAsync() => (await GetAsync(new Query<TEntity>())).Items;
+        public async Task<IEnumerable<TEntity>> GetAllAsync() => (await GetAsync(new Query<TEntity> { Page = Page.Unlimited })).Items;
 
         public virtual async Task<ISelection<TEntity>> GetAsync(Query<TEntity> query)
         {

--- a/Domain/RDD.Domain/Models/ReadOnlyRestCollection.cs
+++ b/Domain/RDD.Domain/Models/ReadOnlyRestCollection.cs
@@ -27,8 +27,6 @@ namespace RDD.Domain.Models
             return (await GetAsync(query)).Count > 0;
         }
 
-        public async Task<IEnumerable<TEntity>> GetAllAsync() => (await GetAsync(new Query<TEntity> { Page = Page.Unlimited })).Items;
-
         public virtual async Task<ISelection<TEntity>> GetAsync(Query<TEntity> query)
         {
             var count = 0;

--- a/Infra/RDD.Infra/Storage/ReadOnlyRepository.cs
+++ b/Infra/RDD.Infra/Storage/ReadOnlyRepository.cs
@@ -20,10 +20,7 @@ namespace RDD.Infra.Storage
             RightExpressionsHelper = rightExpressionsHelper;
         }
 
-        public virtual Task<int> CountAsync()
-        {
-            return CountAsync(new Query<TEntity> { Page = Page.Unlimited });
-        }
+        public virtual Task<int> CountAsync() => CountAsync(new Query<TEntity>());
         public virtual Task<int> CountAsync(Query<TEntity> query)
         {
             var entities = Set(query);

--- a/Infra/RDD.Infra/Storage/ReadOnlyRepository.cs
+++ b/Infra/RDD.Infra/Storage/ReadOnlyRepository.cs
@@ -22,7 +22,7 @@ namespace RDD.Infra.Storage
 
         public virtual Task<int> CountAsync()
         {
-            return CountAsync(new Query<TEntity>());
+            return CountAsync(new Query<TEntity> { Page = Page.Unlimited });
         }
         public virtual Task<int> CountAsync(Query<TEntity> query)
         {


### PR DESCRIPTION
lorsqu'on définit une Query avec un filtre, c'est qu'on sait cee qu'on fait, et donc qu'on ne veut pas être surpris par le paging