### PR TITLE
MOD : IStorageService moved to Application layer

### DIFF
--- a/Application/RDD.Application/Controllers/AppController.cs
+++ b/Application/RDD.Application/Controllers/AppController.cs
@@ -1,6 +1,5 @@
 ﻿using RDD.Domain;
 using RDD.Domain.Models.Querying;
-using RDD.Infra;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/Application/RDD.Application/IStorageService.cs
+++ b/Application/RDD.Application/IStorageService.cs
@@ -1,10 +1,9 @@
-﻿using RDD.Domain;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace RDD.Infra
+namespace RDD.Application
 {
     public interface IStorageService : IDisposable
     {

--- a/Application/RDD.Application/RDD.Application.csproj
+++ b/Application/RDD.Application/RDD.Application.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Domain\RDD.Domain\RDD.Domain.csproj" />
-    <ProjectReference Include="..\..\Infra\RDD.Infra\RDD.Infra.csproj" />
   </ItemGroup>
   
 </Project>

--- a/Domain/RDD.Domain.Tests/Models/OpenRepository.cs
+++ b/Domain/RDD.Domain.Tests/Models/OpenRepository.cs
@@ -1,6 +1,6 @@
-﻿using RDD.Domain.Models.Querying;
+﻿using RDD.Application;
+using RDD.Domain.Models.Querying;
 using RDD.Domain.Rights;
-using RDD.Infra;
 using RDD.Infra.Storage;
 using System.Linq;
 

--- a/Domain/RDD.Domain.Tests/Models/UsersAppController.cs
+++ b/Domain/RDD.Domain.Tests/Models/UsersAppController.cs
@@ -1,5 +1,5 @@
-﻿using RDD.Application.Controllers;
-using RDD.Infra;
+﻿using RDD.Application;
+using RDD.Application.Controllers;
 
 namespace RDD.Domain.Tests.Models
 {

--- a/Domain/RDD.Domain.Tests/QueryTests.cs
+++ b/Domain/RDD.Domain.Tests/QueryTests.cs
@@ -1,8 +1,8 @@
-﻿using RDD.Domain.Helpers;
+﻿using RDD.Application;
+using RDD.Domain.Helpers;
 using RDD.Domain.Models.Querying;
 using RDD.Domain.Tests.Models;
 using RDD.Domain.Tests.Templates;
-using RDD.Infra;
 using RDD.Infra.Storage;
 using System;
 using Xunit;

--- a/Domain/RDD.Domain.Tests/Templates/SingleContextTests.cs
+++ b/Domain/RDD.Domain.Tests/Templates/SingleContextTests.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using RDD.Application;
 using RDD.Domain.Mocks;
 using RDD.Domain.Models;
 using RDD.Domain.Patchers;
 using RDD.Domain.Rights;
 using RDD.Domain.Tests.Models;
-using RDD.Infra;
 using RDD.Infra.Storage;
 using System;
 

--- a/Infra/RDD.Infra/RDD.Infra.csproj
+++ b/Infra/RDD.Infra/RDD.Infra.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Application\RDD.Application\RDD.Application.csproj" />
     <ProjectReference Include="..\..\Domain\RDD.Domain\RDD.Domain.csproj" />
   </ItemGroup>
 

--- a/Infra/RDD.Infra/Storage/EFStorageService.cs
+++ b/Infra/RDD.Infra/Storage/EFStorageService.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using RDD.Domain;
+using RDD.Application;
 using RDD.Infra.Exceptions;
 using System;
 using System.Collections.Generic;

--- a/Infra/RDD.Infra/Storage/InMemoryStorageService.cs
+++ b/Infra/RDD.Infra/Storage/InMemoryStorageService.cs
@@ -1,4 +1,5 @@
-﻿using RDD.Domain;
+﻿using RDD.Application;
+using RDD.Domain;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Infra/RDD.Infra/Storage/ReadOnlyRepository.cs
+++ b/Infra/RDD.Infra/Storage/ReadOnlyRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using RDD.Application;
 using RDD.Domain;
 using RDD.Domain.Helpers.Expressions;
 using RDD.Domain.Models.Querying;

--- a/Infra/RDD.Infra/Storage/Repository.cs
+++ b/Infra/RDD.Infra/Storage/Repository.cs
@@ -1,4 +1,5 @@
-﻿using RDD.Domain;
+﻿using RDD.Application;
+using RDD.Domain;
 using RDD.Domain.Rights;
 using System.Collections.Generic;
 

--- a/Web/RDD.Web.Tests/CollectionPropertiesTests.cs
+++ b/Web/RDD.Web.Tests/CollectionPropertiesTests.cs
@@ -1,8 +1,7 @@
-﻿using RDD.Domain;
-using RDD.Domain.Models.Querying;
+﻿using RDD.Application;
+using RDD.Domain;
 using RDD.Domain.Tests.Models;
 using RDD.Domain.Tests.Templates;
-using RDD.Infra;
 using RDD.Web.Querying;
 using System;
 using System.Linq;

--- a/Web/RDD.Web.Tests/WebPagingTests.cs
+++ b/Web/RDD.Web.Tests/WebPagingTests.cs
@@ -1,9 +1,9 @@
-﻿using RDD.Domain;
+﻿using RDD.Application;
+using RDD.Domain;
 using RDD.Domain.Exceptions;
 using RDD.Domain.Models.Querying;
 using RDD.Domain.Tests.Models;
 using RDD.Domain.Tests.Templates;
-using RDD.Infra;
 using RDD.Web.Querying;
 using System;
 using System.Collections.Generic;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,7 @@
  - **Modification**: `IAppController.DeleteByIdsAsync(IEnumerable<TKey> ids) -> IAppController.DeleteByIdsAsync(IList<TKey> ids)`. This breaking change might require you to change your override signatures.
  - **Modification**: `IRestCollection.DeleteByIdsAsync(IEnumerable<TKey> ids) -> IAppController.DeleteByIdsAsync(IList<TKey> ids)`. This breaking change might require you to change your override signatures.
  - **Modification**: Error messages have been modified.
+ - **Modification**: IStorageService is now located inside the Application layer, namespace `RDD.Application`.
 
 ## New features
  - **Added**: CHANGELOG.md


### PR DESCRIPTION
IStorageService is an abstraction on which the Application layer depends, that is implemented in the Infrastructure layer.

Since it's the web layer that plug concrete infra implementations to application/domain abstraction, infra layer can depend on the application layer.

I have moved the IStorageService inside the application layer, and inverted the dependency between infra and application

Resolves #170