### PR TITLE
ADD : recherche fulltext

### DIFF
--- a/Infra/RDD.Infra/Helpers/PredicateService.cs
+++ b/Infra/RDD.Infra/Helpers/PredicateService.cs
@@ -93,6 +93,7 @@ namespace RDD.Infra.Helpers
                 case WebFilterOperand.NotEqual: return queryBuilder.NotEqual(filter.Selector, value);
                 case WebFilterOperand.Starts: return queryBuilder.Starts(filter.Selector, value);
                 case WebFilterOperand.Like: return queryBuilder.Like(filter.Selector, value);
+                case WebFilterOperand.FullText: return queryBuilder.FullText(filter.Selector, value);
                 case WebFilterOperand.Between: return queryBuilder.Between(filter.Selector, value);
                 case WebFilterOperand.Since: return queryBuilder.Since(filter.Selector, value);
                 case WebFilterOperand.Until: return queryBuilder.Until(filter.Selector, value);

--- a/Infra/RDD.Infra/Web/Models/WebFilterOperand.cs
+++ b/Infra/RDD.Infra/Web/Models/WebFilterOperand.cs
@@ -16,6 +16,8 @@ namespace RDD.Infra.Web.Models
         Starts,
         [Description("Filter on data containing the following text. usage : users?name=like,a")]
         Like,
+        [Description("full-text search on a compatible field")]
+        FullText,
         [Description("Filter on date for which value is between following parameters. usage : users?dtContractEnd=between,2013-01-01,2014-01-01")]
         Between,
         /// <summary>

--- a/Web/RDD.Web.Tests/QueryBuilderTests.cs
+++ b/Web/RDD.Web.Tests/QueryBuilderTests.cs
@@ -219,5 +219,18 @@ namespace RDD.Web.Tests
             Assert.Equal(users[0], goodUser);
             Assert.Equal(users[1], goodUser2);
         }
+
+        [Fact]
+        public void FullTextFilter()
+        {
+            var builder = new QueryBuilder<User, int>();
+            var expression = builder.FullText(PropertyExpression<User>.New(u => u.Name), new List<string> { "search" });
+
+            var goodUser = new User { Name = "searched" };
+            var goodUser2 = new User { Name = "aa search" };
+            var badUser = new User { Name = "searzedzech" };
+
+            Assert.Throws<InvalidOperationException>(() => new List<User> { goodUser, goodUser2, badUser }.AsQueryable().Where(expression).ToList());
+        }
     }
 }

--- a/Web/RDD.Web/Querying/WebFiltersParser.cs
+++ b/Web/RDD.Web/Querying/WebFiltersParser.cs
@@ -22,6 +22,7 @@ namespace RDD.Web.Querying
             {"equals", WebFilterOperand.Equals},
             {"notequal", WebFilterOperand.NotEqual},
             {"like", WebFilterOperand.Like},
+            {"fulltext", WebFilterOperand.FullText},
             {"since", WebFilterOperand.Since},
             {"starts", WebFilterOperand.Starts},
             {"until", WebFilterOperand.Until},


### PR DESCRIPTION
gestion de champs disponibles en recherche full text. Necessite un champ qui supporteça + qui porte le même nom que le champ c#.

Je propose la syntaxe suivante : name=fulltext,blabla. Applique le filtre en SQL, bien entendu.