### PR TITLE
REF Tests

### DIFF
--- a/Domain/RDD.Domain.Tests/AppControllerTests.cs
+++ b/Domain/RDD.Domain.Tests/AppControllerTests.cs
@@ -1,6 +1,5 @@
 ﻿using RDD.Domain.Models.Querying;
 using RDD.Domain.Tests.Models;
-using RDD.Domain.Tests.Templates;
 using RDD.Infra.Storage;
 using RDD.Web.Models;
 using System;
@@ -11,66 +10,65 @@ using Xunit;
 
 namespace RDD.Domain.Tests
 {
-    public class AppControllerTests : SingleContextTests
+    public class AppControllerTests : IClassFixture<DefaultFixture>
     {
+        private DefaultFixture _fixture;
+
+        public AppControllerTests(DefaultFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         [Fact]
         public async Task PostShouldNotCallGetByIdOnTheCollection()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
-            {
-                var repo = new Repository<User>(storage, _rightsService);
-                var users = new UsersCollectionWithHardcodedGetById(repo, _patcherProvider, Instanciator);
-                var controller = new UsersAppController(storage, users);
-                var query = new Query<User>();
-                query.Options.CheckRights = false;
-                var candidate = Candidate<User, int>.Parse(@"{ ""id"": 3 }");
+            var users = new UsersCollectionWithHardcodedGetById(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
+            var controller = new UsersAppController(_fixture.InMemoryStorage, users);
+            var query = new Query<User>();
+            query.Options.CheckRights = false;
+            var id = Guid.NewGuid();
+            var candidate = Candidate<User, Guid>.Parse($@"{{ ""id"": ""{id}"" }}");
 
-                var user = await controller.CreateAsync(candidate, query);
+            var user = await controller.CreateAsync(candidate, query);
 
-                Assert.Equal(3, user.Id);
-            }
+            Assert.Equal(id, user.Id);
         }
 
         [Fact]
         public async Task PostShouldNotCallGetByIdsOnTheCollection()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
-            {
-                var repo = new Repository<User>(storage, _rightsService);
-                var users = new UsersCollectionWithHardcodedGetById(repo, _patcherProvider, Instanciator);
-                var controller = new UsersAppController(storage, users);
-                var query = new Query<User>();
-                query.Options.CheckRights = false;
-                var candidate1 = Candidate<User, int>.Parse(@"{ ""id"": 3 }");
-                var candidate2 = Candidate<User, int>.Parse(@"{ ""id"": 4 }");
+            var users = new UsersCollectionWithHardcodedGetById(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
+            var controller = new UsersAppController(_fixture.InMemoryStorage, users);
+            var query = new Query<User>();
+            query.Options.CheckRights = false;
+            var id1 = Guid.NewGuid();
+            var id2 = Guid.NewGuid();
+            var candidate1 = Candidate<User, Guid>.Parse($@"{{ ""id"": ""{id1}"" }}");
+            var candidate2 = Candidate<User, Guid>.Parse($@"{{ ""id"": ""{id2}"" }}");
 
-                var result = (await controller.CreateAsync(new List<Candidate<User, int>> { candidate1, candidate2 }, query)).ToList();
+            var result = (await controller.CreateAsync(new List<Candidate<User, Guid>> { candidate1, candidate2 }, query)).ToList();
 
-                Assert.Equal(3, result[0].Id);
-                Assert.Equal(4, result[1].Id);
-            }
+            Assert.Equal(id1, result[0].Id);
+            Assert.Equal(id2, result[1].Id);
         }
 
         [Fact]
         public async Task PutShouldNotCallGetByIdOnTheCollection()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
-            {
-                var repo = new Repository<User>(storage, _rightsService);
-                var users = new UsersCollectionWithHardcodedGetById(repo, _patcherProvider, Instanciator);
-                var controller = new UsersAppController(storage, users);
-                var query = new Query<User>();
-                query.Options.CheckRights = false;
-                var candidate = Candidate<User, int>.Parse(@"{ ""id"": 3 }");
+            var users = new UsersCollectionWithHardcodedGetById(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
+            var controller = new UsersAppController(_fixture.InMemoryStorage, users);
+            var query = new Query<User>();
+            query.Options.CheckRights = false;
+            var id = Guid.NewGuid();
+            var candidate = Candidate<User, Guid>.Parse($@"{{ ""id"": ""{id}"" }}");
 
-                await controller.CreateAsync(candidate, query);
+            await controller.CreateAsync(candidate, query);
 
-                candidate = Candidate<User, int>.Parse(@"{ ""name"": ""newName"" }");
+            candidate = Candidate<User, Guid>.Parse($@"{{ ""name"": ""newName"" }}");
 
-                var user = await controller.UpdateByIdAsync(3, candidate, query);
+            var user = await controller.UpdateByIdAsync(id, candidate, query);
 
-                Assert.Equal(3, user.Id);
-            }
+            Assert.Equal(id, user.Id);
         }
     }
 }

--- a/Domain/RDD.Domain.Tests/CollectionMethodsTests.cs
+++ b/Domain/RDD.Domain.Tests/CollectionMethodsTests.cs
@@ -1,14 +1,12 @@
 ﻿using Moq;
 using Newtonsoft.Json;
 using RDD.Domain.Exceptions;
-using RDD.Domain.Helpers;
 using RDD.Domain.Mocks;
 using RDD.Domain.Models;
 using RDD.Domain.Models.Querying;
 using RDD.Domain.Patchers;
 using RDD.Domain.Rights;
 using RDD.Domain.Tests.Models;
-using RDD.Domain.Tests.Templates;
 using RDD.Infra.Storage;
 using RDD.Web.Models;
 using System;
@@ -16,54 +14,52 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Xunit;
+
 namespace RDD.Domain.Tests
 {
-    public class CollectionMethodsTests : SingleContextTests
+    public class CollectionMethodsTests : IClassFixture<DefaultFixture>
     {
+        private DefaultFixture _fixture;
+
+        public CollectionMethodsTests(DefaultFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
         [Fact]
         public async Task GetById_SHOULD_not_throw_exception_and_return_null_WHEN_id_does_not_exist()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
-            {
-                var repo = new Repository<User>(storage, _rightsService);
-                var users = new UsersCollection(repo, _patcherProvider, Instanciator);
+            var users = new UsersCollection(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
 
-                Assert.Null(await users.GetByIdAsync(0, new Query<User>()));
-            }
+            Assert.Null(await users.GetByIdAsync(Guid.NewGuid(), new Query<User>()));
         }
 
         [Fact]
         public async Task Put_SHOULD_NOT_throw_notfound_exception_WHEN_unexisting_entity_()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
-            {
-                Expression<Func<User, bool>> trueFilter = t => true;
-                var rightService = new Mock<IRightExpressionsHelper<User>>();
-                rightService.Setup(s => s.GetFilter(It.IsAny<Query<User>>())).Returns(trueFilter);
+            Expression<Func<User, bool>> trueFilter = t => true;
+            var rightService = new Mock<IRightExpressionsHelper<User>>();
+            rightService.Setup(s => s.GetFilter(It.IsAny<Query<User>>())).Returns(trueFilter);
 
-                var user = new User { Id = 3 };
-                var repo = new Repository<User>(storage, rightService.Object);
-                var users = new UsersCollection(repo, _patcherProvider, Instanciator);
-                var app = new UsersAppController(storage, users);
+            var id = Guid.NewGuid();
+            var user = new User { Id = id };
+            var repo = new Repository<User>(_fixture.InMemoryStorage, rightService.Object);
+            var users = new UsersCollection(repo, _fixture.PatcherProvider, _fixture.Instanciator);
+            var app = new UsersAppController(_fixture.InMemoryStorage, users);
 
-                await app.CreateAsync(Candidate<User, int>.Parse(@"{ ""id"": 3 }"), new Query<User>());
+            await app.CreateAsync(Candidate<User, Guid>.Parse($@"{{ ""id"": ""{id}"" }}"), new Query<User>());
 
-                await app.UpdateByIdAsync(0, Candidate<User, int>.Parse(@"{ ""name"": ""new name"" }"), new Query<User>());
-            }
+            await app.UpdateByIdAsync(Guid.NewGuid(), Candidate<User, Guid>.Parse(@"{ ""name"": ""new name"" }"), new Query<User>());
         }
 
         [Fact]
         public async Task Post_SHOULD_work_WHEN_InstantiateEntityIsNotOverridenAndEntityHasAParameterlessConstructor()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
-            {
-                var repo = new Repository<User>(storage, _rightsService);
-                var users = new UsersCollection(repo, _patcherProvider, Instanciator);
-                var query = new Query<User>();
-                query.Options.CheckRights = false;
+            var users = new UsersCollection(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
+            var query = new Query<User>();
+            query.Options.CheckRights = false;
 
-                await users.CreateAsync(Candidate<User, int>.Parse(@"{ ""id"": 3 }"), query);
-            }
+            await users.CreateAsync(Candidate<User, Guid>.Parse($@"{{ ""id"": ""{Guid.NewGuid()}"" }}"), query);
         }
 
         class InstanciatorImplementation : IInstanciator<UserWithParameters>
@@ -80,126 +76,107 @@ namespace RDD.Domain.Tests
         [Fact]
         public async Task Post_SHOULD_work_WHEN_InstantiateEntityIsOverridenAndEntityHasParametersInConstructor()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
-            {
-                var repo = new Repository<UserWithParameters>(storage, new RightsServiceMock<UserWithParameters>());
-                var users = new UsersCollectionWithParameters(repo, _patcherProvider, new InstanciatorImplementation());
-                var query = new Query<UserWithParameters>();
-                query.Options.CheckRights = false;
+            var repo = new Repository<UserWithParameters>(_fixture.InMemoryStorage, new RightsServiceMock<UserWithParameters>());
+            var users = new UsersCollectionWithParameters(repo, _fixture.PatcherProvider, new InstanciatorImplementation());
+            var query = new Query<UserWithParameters>();
+            query.Options.CheckRights = false;
 
-                var result = await users.CreateAsync(Candidate<UserWithParameters, int>.Parse(@"{ ""id"": 3, ""name"": ""John"" }"), query);
+            var result = await users.CreateAsync(Candidate<UserWithParameters, int>.Parse($@"{{ ""id"": 3, ""name"": ""John"" }}"), query);
 
-                Assert.Equal(3, result.Id);
-                Assert.Equal("John", result.Name);
-            }
+            Assert.Equal(3, result.Id);
+            Assert.Equal("John", result.Name);
         }
 
         [Fact]
         public async Task AnyAsync_should_work()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
-            {
-                var user = new User { Id = 2 };
-                var repo = new Repository<User>(storage, _rightsService);
-                var users = new UsersCollection(repo, _patcherProvider, Instanciator);
-                var query = new Query<User>();
-                query.Options.CheckRights = false;
-                
-                storage.Add(user);
-                await storage.SaveChangesAsync();
+            var id = Guid.NewGuid();
+            var user = new User { Id = id };
+            var users = new UsersCollection(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
+            var query = new Query<User>();
+            query.Options.CheckRights = false;
 
-                var any = await users.AnyAsync(query);
+            _fixture.InMemoryStorage.Add(user);
+            await _fixture.InMemoryStorage.SaveChangesAsync();
 
-                Assert.True(any);
-            }
+            var any = await users.AnyAsync(query);
+
+            Assert.True(any);
         }
 
         [Fact]
         public async Task Put_serializedEntity_should_work()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
-            {
-                var user = new User { Id = 2, Name = "Name", Salary = 1, TwitterUri = new Uri("https://twitter.com") };
-                var repo = new Repository<User>(storage, _rightsService);
-                var users = new UsersCollection(repo, _patcherProvider, Instanciator);
-                var query = new Query<User>();
-                query.Options.CheckRights = false;
-                
-                storage.Add(user);
-                await storage.SaveChangesAsync();
+            var id = Guid.NewGuid();
+            var user = new User { Id = id, Name = "Name", Salary = 1, TwitterUri = new Uri("https://twitter.com") };
+            var users = new UsersCollection(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
+            var query = new Query<User>();
+            query.Options.CheckRights = false;
 
-                await users.UpdateByIdAsync(2, Candidate<User, int>.Parse(JsonConvert.SerializeObject(user)), query);
+            _fixture.InMemoryStorage.Add(user);
+            await _fixture.InMemoryStorage.SaveChangesAsync();
 
-                Assert.True(true);
-            }
+            await users.UpdateByIdAsync(id, Candidate<User, Guid>.Parse(JsonConvert.SerializeObject(user)), query);
+
+            Assert.True(true);
         }
 
         [Fact]
         public async Task Get_withFilters_shouldWork()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
-            {
-                var user = new User { Id = 2, Name = "Name", Salary = 1, TwitterUri = new Uri("https://twitter.com") };
-                var repo = new Repository<User>(storage, _rightsService);
-                var users = new UsersCollection(repo, _patcherProvider, Instanciator);
-                var query = new Query<User>();
-                query.Options.CheckRights = false;
+            var id = Guid.NewGuid();
+            var user = new User { Id = id, Name = "Name", Salary = 1, TwitterUri = new Uri("https://twitter.com") };
+            var users = new UsersCollection(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
+            var query = new Query<User>();
+            query.Options.CheckRights = false;
 
-                storage.Add(user);
-                await storage.SaveChangesAsync();
+            _fixture.InMemoryStorage.Add(user);
+            await _fixture.InMemoryStorage.SaveChangesAsync();
 
-                query = new Query<User>(query, u => u.TwitterUri == new Uri("https://twitter.com"));
+            query = new Query<User>(query, u => u.TwitterUri == new Uri("https://twitter.com"));
 
-                var results = await users.GetAsync(query);
+            var results = await users.GetAsync(query);
 
-                Assert.Equal(1, results.Count);
-            }
+            Assert.Equal(1, results.Count);
         }
 
         [Fact]
         public void Collection_on_hierarchy_fails()
         {
             Assert.ThrowsAsync<BadRequestException>(async () =>
-           {
-               using (var storage = _newStorage(Guid.NewGuid().ToString()))
-               {
-                   var repo = new Repository<Hierarchy>(storage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
-                   var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
-                   var collection = new RestCollection<Hierarchy, int>(repo, new ObjectPatcher<Hierarchy>(_patcherProvider), instanciator);
+            {
+                var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
+                var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
+                var collection = new RestCollection<Hierarchy, int>(repo, new ObjectPatcher<Hierarchy>(_fixture.PatcherProvider), instanciator);
 
-                   JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-                   {
-                       Converters = new List<JsonConverter>
-                   {
+                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+                {
+                    Converters = new List<JsonConverter>
+                    {
                         new BaseClassJsonConverter<Hierarchy>(new InheritanceConfiguration())
-                   }
-                   };
-                   var candidate = Candidate<Hierarchy, int>.Parse(@"{ ""type"":""super"", ""superProperty"": ""lol"" }");
-                   await collection.CreateAsync(candidate);
-               }
-           });
+                    }
+                };
+                var candidate = Candidate<Hierarchy, int>.Parse(@"{ ""type"":""super"", ""superProperty"": ""lol"" }");
+                await collection.CreateAsync(candidate);
+            });
         }
 
         [Fact]
         public async Task BaseClass_Collection_on_hierarchy_works()
         {
-            using (var storage = _newStorage(Guid.NewGuid().ToString()))
+            var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
+            var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
+            var collection = new RestCollection<Hierarchy, int>(repo, new BaseClassPatcher<Hierarchy>(_fixture.PatcherProvider, new InheritanceConfiguration()), instanciator);
+
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
             {
-                var repo = new Repository<Hierarchy>(storage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
-                var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
-                var collection = new RestCollection<Hierarchy, int>(repo, new BaseClassPatcher<Hierarchy>(_patcherProvider, new InheritanceConfiguration()), instanciator);
-
-                JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-                {
-                    Converters = new List<JsonConverter>
-                   {
+                Converters = new List<JsonConverter>
+                    {
                         new BaseClassJsonConverter<Hierarchy>(new InheritanceConfiguration())
-                   }
-                };
-                var candidate = Candidate<Hierarchy, int>.Parse(@"{ ""type"":""super"", ""superProperty"": ""lol"" }");
-                await collection.CreateAsync(candidate);
-            }
+                    }
+            };
+            var candidate = Candidate<Hierarchy, int>.Parse(@"{ ""type"":""super"", ""superProperty"": ""lol"" }");
+            await collection.CreateAsync(candidate);
         }
-
     }
 }

--- a/Domain/RDD.Domain.Tests/DefaultFixture.cs
+++ b/Domain/RDD.Domain.Tests/DefaultFixture.cs
@@ -1,0 +1,31 @@
+﻿using RDD.Application;
+using RDD.Domain.Mocks;
+using RDD.Domain.Models;
+using RDD.Domain.Patchers;
+using RDD.Domain.Rights;
+using RDD.Domain.Tests.Models;
+using RDD.Infra.Storage;
+using System;
+
+namespace RDD.Domain.Tests
+{
+    public class DefaultFixture : IDisposable
+    {
+        public IRightExpressionsHelper<User> RightsService { get; private set; }
+        public IPatcherProvider PatcherProvider { get; private set; }
+        public IInstanciator<User> Instanciator { get; private set; }
+        public IStorageService InMemoryStorage { get; private set; }
+        public IRepository<User> UsersRepo { get; private set; }
+
+        public DefaultFixture()
+        {
+            RightsService = new RightsServiceMock<User>();
+            PatcherProvider = new PatcherProvider();
+            Instanciator = new DefaultInstanciator<User>();
+            InMemoryStorage = new InMemoryStorageService();
+            UsersRepo = new Repository<User>(InMemoryStorage, RightsService);
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/Domain/RDD.Domain.Tests/Models/User.cs
+++ b/Domain/RDD.Domain.Tests/Models/User.cs
@@ -5,9 +5,9 @@ using System.Net.Mail;
 
 namespace RDD.Domain.Tests.Models
 {
-    public class User : EntityBase<User, int>
+    public class User : EntityBase<User, Guid>
     {
-        public override int Id { get; set; }
+        public override Guid Id { get; set; }
         public override string Name { get; set; }
         public MailAddress Mail { get; set; }
         public Uri TwitterUri { get; set; }
@@ -22,8 +22,9 @@ namespace RDD.Domain.Tests.Models
             for (var i = 1; i <= howMuch; i++)
             {
                 var name = $"John Doe {i}";
+                var id = Guid.NewGuid();
 
-                result.Add(new User { Id = i, Name = name });
+                result.Add(new User { Id = id, Name = name });
             }
 
             return result;

--- a/Domain/RDD.Domain.Tests/Models/UserWithParameters.cs
+++ b/Domain/RDD.Domain.Tests/Models/UserWithParameters.cs
@@ -26,8 +26,9 @@ namespace RDD.Domain.Tests.Models
             for (var i = 1; i <= howMuch; i++)
             {
                 var name = $"John Doe {i}";
+                var id = Guid.NewGuid();
 
-                result.Add(new User { Id = i, Name = name });
+                result.Add(new User { Id = id, Name = name });
             }
 
             return result;

--- a/Domain/RDD.Domain.Tests/Models/UsersAppController.cs
+++ b/Domain/RDD.Domain.Tests/Models/UsersAppController.cs
@@ -1,9 +1,10 @@
-﻿using RDD.Application;
+using RDD.Application;
 using RDD.Application.Controllers;
+using System;
 
 namespace RDD.Domain.Tests.Models
 {
-    public class UsersAppController : AppController<UsersCollection, User, int>
+    public class UsersAppController : AppController<UsersCollection, User, Guid>
     {
         public UsersAppController(IStorageService storage, UsersCollection collection)
             : base(storage, collection) { }

--- a/Domain/RDD.Domain.Tests/Models/UsersCollection.cs
+++ b/Domain/RDD.Domain.Tests/Models/UsersCollection.cs
@@ -1,9 +1,10 @@
 ﻿using RDD.Domain.Models;
 using RDD.Domain.Patchers;
+using System;
 
 namespace RDD.Domain.Tests.Models
 {
-    public class UsersCollection : RestCollection<User, int>
+    public class UsersCollection : RestCollection<User, Guid>
     {
         public UsersCollection(IRepository<User> repository, IPatcherProvider patcherProvider, IInstanciator<User> instanciator)
             : base(repository, new ObjectPatcher<User>(patcherProvider), instanciator) { }

--- a/Domain/RDD.Domain.Tests/Models/UsersCollectionWithHardcodedGetById.cs
+++ b/Domain/RDD.Domain.Tests/Models/UsersCollectionWithHardcodedGetById.cs
@@ -1,6 +1,7 @@
 ﻿using RDD.Domain.Models;
 using RDD.Domain.Models.Querying;
 using RDD.Domain.Patchers;
+using System;
 using System.Threading.Tasks;
 
 namespace RDD.Domain.Tests.Models
@@ -10,14 +11,14 @@ namespace RDD.Domain.Tests.Models
         public UsersCollectionWithHardcodedGetById(IRepository<User> repository, IPatcherProvider patcherProvider, IInstanciator<User> instanciator)
             : base(repository, patcherProvider, instanciator) { }
 
-        public override Task<User> GetByIdAsync(int id, Query<User> query)
+        public override Task<User> GetByIdAsync(Guid id, Query<User> query)
         {
             //Only for get, because PUT will always make a GetById( ) to retrieve the entity to update
             if (query.Verb == Helpers.HttpVerbs.Get)
             {
                 return Task.FromResult(new User
                 {
-                    Id = 4
+                    Id = Guid.NewGuid()
                 });
             }
 

--- a/Domain/RDD.Domain.Tests/OrderByConverterTests.cs
+++ b/Domain/RDD.Domain.Tests/OrderByConverterTests.cs
@@ -1,5 +1,6 @@
 ﻿using RDD.Domain.Models.Querying;
 using RDD.Domain.Tests.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -23,20 +24,23 @@ namespace RDD.Domain.Tests
         public void SimpleOrdersByShouldWork()
         {
             var orderby1 = OrderBy<User>.Ascending(u => u.Name);
-            var orderby2 = OrderBy<User>.Ascending(u => u.Id);
+            var orderby2 = OrderBy<User>.Ascending(u => u.Salary);
+            var id30 = Guid.NewGuid();
+            var id0 = Guid.NewGuid();
+            var id35 = Guid.NewGuid();
             var users = new List<User>
             {
-                new User { Name = "bName", Id = 30},
-                new User { Name = "bName", Id = 0},
-                new User { Name = "aName", Id = 35 }
+                new User { Name = "bName", Id = id30, Salary = 30},
+                new User { Name = "bName", Id = id0, Salary = 0},
+                new User { Name = "aName", Id = id35, Salary = 35 }
             }.AsQueryable();
 
             var results = orderby1.ApplyOrderBy(users);
             results = orderby2.ApplyOrderBy(results);
 
-            Assert.Equal(35, results.ElementAt(0).Id);
-            Assert.Equal(0, results.ElementAt(1).Id);
-            Assert.Equal(30, results.ElementAt(2).Id);
+            Assert.Equal(id35, results.ElementAt(0).Id);
+            Assert.Equal(id0, results.ElementAt(1).Id);
+            Assert.Equal(id30, results.ElementAt(2).Id);
         }
 
         [Fact]
@@ -46,24 +50,30 @@ namespace RDD.Domain.Tests
             var orderby2 = OrderBy<User>.Ascending(u => u.Salary);
             var orderby3 = OrderBy<User>.Descending(u => u.Id);
 
+            var id26 = new Guid("26000000-0000-0000-0000-000000000000");
+            var id27 = new Guid("27000000-0000-0000-0000-000000000000");
+            var id28 = new Guid("28000000-0000-0000-0000-000000000000");
+            var id29 = new Guid("29000000-0000-0000-0000-000000000000");
+            var id30 = new Guid("30000000-0000-0000-0000-000000000000");
+
             var users = new List<User>
             {
-                new User { Name = "b", Id = 26, Salary = 30},
-                new User { Name = "b", Id = 27, Salary = 0},
-                new User { Name = "b", Id = 28, Salary = 30},
-                new User { Name = "a", Id = 29},
-                new User { Name = "a", Id = 30},
+                new User { Name = "b", Id = id26, Salary = 30},
+                new User { Name = "b", Id = id27, Salary = 0},
+                new User { Name = "b", Id = id28, Salary = 30},
+                new User { Name = "a", Id = id29},
+                new User { Name = "a", Id = id30},
             }.AsQueryable();
 
             var results = orderby1.ApplyOrderBy(users);
             results = orderby2.ApplyOrderBy(results);
             results = orderby3.ApplyOrderBy(results);
 
-            Assert.Equal(30, results.ElementAt(0).Id);
-            Assert.Equal(29, results.ElementAt(1).Id);
-            Assert.Equal(27, results.ElementAt(2).Id);
-            Assert.Equal(28, results.ElementAt(3).Id);
-            Assert.Equal(26, results.ElementAt(4).Id);
+            Assert.Equal(id30, results.ElementAt(0).Id);
+            Assert.Equal(id29, results.ElementAt(1).Id);
+            Assert.Equal(id27, results.ElementAt(2).Id);
+            Assert.Equal(id28, results.ElementAt(3).Id);
+            Assert.Equal(id26, results.ElementAt(4).Id);
         }
     }
 }

--- a/Domain/RDD.Domain.Tests/PropertySelectorCollectionTests.cs
+++ b/Domain/RDD.Domain.Tests/PropertySelectorCollectionTests.cs
@@ -1,5 +1,4 @@
-﻿using RDD.Domain.Helpers;
-using RDD.Domain.Helpers.Expressions;
+﻿using RDD.Domain.Helpers.Expressions;
 using RDD.Domain.Tests.Models;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/Domain/RDD.Domain.Tests/QueryTests.cs
+++ b/Domain/RDD.Domain.Tests/QueryTests.cs
@@ -3,25 +3,13 @@ using RDD.Domain.Helpers;
 using RDD.Domain.Models.Querying;
 using RDD.Domain.Tests.Models;
 using RDD.Domain.Tests.Templates;
-using RDD.Infra.Storage;
 using System;
 using Xunit;
 
 namespace RDD.Domain.Tests
 {
-    public class QueryTests : SingleContextTests
+    public class QueryTests
     {
-        private readonly IRepository<User> _repo;
-        private IReadOnlyRestCollection<User, int> _collection;
-        private readonly IStorageService _storage;
-
-        public QueryTests()
-        {
-            _storage = _newStorage(Guid.NewGuid().ToString());
-            _repo = new Repository<User>(_storage, _rightsService);
-            _collection = new UsersCollection(_repo, _patcherProvider, Instanciator);
-        }
-
         [Fact]
         public void Cloning_query_should_clone_verb()
         {

--- a/Infra/RDD.Infra.Tests/CollectionTests.cs
+++ b/Infra/RDD.Infra.Tests/CollectionTests.cs
@@ -1,0 +1,45 @@
+﻿using RDD.Domain.Models.Querying;
+using RDD.Domain.Tests;
+using RDD.Domain.Tests.Models;
+using RDD.Infra.Storage;
+using System.Linq;
+using Xunit;
+
+namespace RDD.Infra.Tests
+{
+    public class CollectionTests : DatabaseTest, IClassFixture<DefaultFixture>
+    {
+        private DefaultFixture _fixture;
+
+        public CollectionTests(DefaultFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async void Guids_ordering_in_sql_should_work_properly()
+        {
+            await RunCodeInsideIsolatedDatabaseAsync(async (context) =>
+            {
+                var storage = new EFStorageService(context);
+                var repo = new UsersRepository(storage, _fixture.RightsService);
+                var collection = new UsersCollection(repo, _fixture.PatcherProvider, _fixture.Instanciator);
+                var users = User.GetManyRandomUsers(20).OrderBy(u => u.Id).ToList();
+                var firstUser = users.ElementAt(0);
+                var tenthUser = users.ElementAt(9);
+                var lastUser = users.ElementAt(19);
+                repo.AddRange(users);
+                await storage.SaveChangesAsync();
+                var result = (await collection.GetAsync(new Query<User>())).Items.ToList();
+
+                var firstItem = result.ElementAt(0);
+                var tenthItem = result.ElementAt(9);
+                var lastItem = result.ElementAt(19);
+
+                Assert.Equal(firstUser, firstItem);
+                Assert.Equal(tenthUser, tenthItem);
+                Assert.Equal(lastUser, lastItem);
+            });
+        }
+    }
+}

--- a/Infra/RDD.Infra.Tests/DatabaseTest.cs
+++ b/Infra/RDD.Infra.Tests/DatabaseTest.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore;
+using RDD.Domain.Tests.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RDD.Infra.Tests
+{
+    public class DatabaseTest
+    {
+        protected virtual DbContext GetContext(string dbName)
+        {
+            return new DataContext(GetOptions(dbName));
+        }
+        protected virtual DbContextOptions<DataContext> GetOptions(string dbName)
+        {
+            return new DbContextOptionsBuilder<DataContext>()
+                .UseSqlServer($@"Server=(localdb)\mssqllocaldb;Database={dbName};Trusted_Connection=True;ConnectRetryCount=0")
+                .Options;
+        }
+
+        public async Task RunCodeInsideIsolatedDatabaseAsync(Func<DbContext, Task> code)
+        {
+            using (var context = GetContext(Guid.NewGuid().ToString()))
+            {
+                try
+                {
+                    await context.Database.EnsureCreatedAsync();
+
+                    await code(context);
+                }
+                finally
+                {
+                    await context.Database.EnsureDeletedAsync();
+                }
+            }
+        }
+    }
+}

--- a/Infra/RDD.Infra.Tests/RDD.Infra.Tests.csproj
+++ b/Infra/RDD.Infra.Tests/RDD.Infra.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Domain\RDD.Domain.Tests\RDD.Domain.Tests.csproj" />
     <ProjectReference Include="..\..\Domain\RDD.Domain\RDD.Domain.csproj" />
     <ProjectReference Include="..\RDD.Infra\RDD.Infra.csproj" />
   </ItemGroup>

--- a/Infra/RDD.Infra.Tests/UsersRepository.cs
+++ b/Infra/RDD.Infra.Tests/UsersRepository.cs
@@ -1,0 +1,24 @@
+﻿using RDD.Application;
+using RDD.Domain.Models.Querying;
+using RDD.Domain.Rights;
+using RDD.Domain.Tests.Models;
+using System.Linq;
+
+namespace RDD.Infra.Tests
+{
+    public class UsersRepository : OpenRepository<User>
+    {
+        public UsersRepository(IStorageService storageService, IRightExpressionsHelper<User> rightsService)
+        : base(storageService, rightsService) { }
+
+        protected override IQueryable<User> ApplyOrderBys(IQueryable<User> entities, Query<User> query)
+        {
+            if (!query.OrderBys.Any())
+            {
+                return entities.OrderBy(u => u.Id.ToString());
+            }
+
+            return base.ApplyOrderBys(entities, query);
+        }
+    }
+}

--- a/Web/RDD.Web.Tests/CollectionPropertiesTests.cs
+++ b/Web/RDD.Web.Tests/CollectionPropertiesTests.cs
@@ -1,25 +1,27 @@
-﻿using RDD.Application;
-using RDD.Domain;
+using RDD.Domain.Tests;
 using RDD.Domain.Tests.Models;
-using RDD.Domain.Tests.Templates;
+using RDD.Infra.Storage;
 using RDD.Web.Querying;
-using System;
 using System.Linq;
 using Xunit;
 
 namespace RDD.Web.Tests
 {
-    public class CollectionPropertiesTests : SingleContextTests
+    public class CollectionPropertiesTests : IClassFixture<DefaultFixture>
     {
-        private readonly IRepository<User> _repo;
-        private readonly IReadOnlyRestCollection<User, int> _collection;
-        private readonly IStorageService _storage;
-        public CollectionPropertiesTests()
+        private DefaultFixture _fixture;
+        private InMemoryStorageService _storage;
+        private OpenRepository<User> _repo;
+        private UsersCollection _collection;
+
+        public CollectionPropertiesTests(DefaultFixture fixture)
         {
-            _storage = _newStorage(Guid.NewGuid().ToString());
-            _repo = new OpenRepository<User>(_storage, _rightsService);
-            _collection = new UsersCollection(_repo, _patcherProvider, Instanciator);
+            _fixture = fixture;
+            _storage = new InMemoryStorageService();
+            _repo = new OpenRepository<User>(_storage, _fixture.RightsService);
+            _collection = new UsersCollection(_repo, _fixture.PatcherProvider, _fixture.Instanciator);
         }
+
         [Fact]
         public async void Count_of_collection_should_tell_10_when_10_entities()
         {
@@ -29,6 +31,7 @@ namespace RDD.Web.Tests
             var result = await _collection.GetAsync(new WebQuery<User>());
             Assert.Equal(10, result.Count);
         }
+
         [Fact]
         public async void Count_of_collection_should_tell_100_when_100_entities()
         {
@@ -38,6 +41,7 @@ namespace RDD.Web.Tests
             var result = await _collection.GetAsync(new WebQuery<User>());
             Assert.Equal(100, result.Count);
         }
+
         [Fact]
         public async void Count_of_collection_should_tell_10000_when_10000_entities()
         {

--- a/Web/RDD.Web.Tests/WebControllerTests.cs
+++ b/Web/RDD.Web.Tests/WebControllerTests.cs
@@ -5,10 +5,7 @@ using RDD.Infra.Storage;
 using RDD.Web.Helpers;
 using RDD.Web.Serialization;
 using RDD.Web.Tests.Models;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/Web/RDD.Web.Tests/WebPagingTests.cs
+++ b/Web/RDD.Web.Tests/WebPagingTests.cs
@@ -1,11 +1,10 @@
-﻿using RDD.Application;
-using RDD.Domain;
+﻿using RDD.Domain;
 using RDD.Domain.Exceptions;
 using RDD.Domain.Models.Querying;
+using RDD.Domain.Tests;
 using RDD.Domain.Tests.Models;
-using RDD.Domain.Tests.Templates;
+using RDD.Infra.Storage;
 using RDD.Web.Querying;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -13,18 +12,20 @@ using Xunit;
 
 namespace RDD.Web.Tests
 {
-    public class WebPaginggTests : SingleContextTests
+    public class WebPaginggTests : IClassFixture<DefaultFixture>
     {
-        public WebPaginggTests()
-        {
-            _storage = _newStorage(Guid.NewGuid().ToString());
-            _repo = new OpenRepository<User>(_storage, _rightsService);
-            _collection = new UsersCollection(_repo, _patcherProvider, Instanciator);
-        }
+        private DefaultFixture _fixture;
+        private InMemoryStorageService _storage;
+        private OpenRepository<User> _repo;
+        private UsersCollection _collection;
 
-        private readonly IRepository<User> _repo;
-        private readonly IReadOnlyRestCollection<User, int> _collection;
-        private readonly IStorageService _storage;
+        public WebPaginggTests(DefaultFixture fixture)
+        {
+            _fixture = fixture;
+            _storage = new InMemoryStorageService();
+            _repo = new OpenRepository<User>(_storage, _fixture.RightsService);
+            _collection = new UsersCollection(_repo, _fixture.PatcherProvider, _fixture.Instanciator);
+        }
 
         [Fact]
         public void Changing_query_page_count_should_not_affect_another_query()


### PR DESCRIPTION
Infra.Tests run under a disposable localdb database, with a GUID name. This ensure that SQL constraints will be respected.

User now has a Guid identity column in order to avoir IDENTITY_INSERT ON/OFF on localdb database (cf https://github.com/aspnet/EntityFrameworkCore/issues/703)

I have used a TestFixture to encapsulate the creation/deletion of the database

Domain & Web tests still use InMemory C# storage for speed.