### PR TITLE
OrderBy sur de Guid

### DIFF
--- a/Domain/RDD.Domain.Tests/Models/User.cs
+++ b/Domain/RDD.Domain.Tests/Models/User.cs
@@ -14,17 +14,15 @@ namespace Rdd.Domain.Tests.Models
         public decimal Salary { get; set; }
         public Department Department { get; set; }
         public Guid PictureId { get; set; }
+        public Guid? FriendId { get; set; }
 
-        public static IEnumerable<User> GetManyRandomUsers(int howMuch)
+        public static IEnumerable<User> GetManyRandomUsers(int count)
         {
             var result = new List<User>();
 
-            for (var i = 1; i <= howMuch; i++)
+            for (var i = 1; i <= count; i++)
             {
-                var name = $"John Doe {i}";
-                var id = Guid.NewGuid();
-
-                result.Add(new User { Id = id, Name = name });
+                result.Add(new User { Id = Guid.NewGuid(), Name = $"John Doe {i}", FriendId = (i % 2 == 0 ? (Guid?)null : Guid.NewGuid()) });
             }
 
             return result;

--- a/Domain/RDD.Domain.Tests/OrderByConverterTests.cs
+++ b/Domain/RDD.Domain.Tests/OrderByConverterTests.cs
@@ -75,5 +75,16 @@ namespace Rdd.Domain.Tests
             Assert.Equal(id28, results.ElementAt(3).Id);
             Assert.Equal(id26, results.ElementAt(4).Id);
         }
+
+        [Fact]
+        public void OrderByToStringShouldWork()
+        {
+            var orderby = OrderBy<User>.Ascending(u => u.Id.ToString());
+            var users = User.GetManyRandomUsers(10).AsQueryable();
+
+            var orderedIds = users.OrderBy(u => u.Id.ToString()).Select(i => i.Id).ToList();            
+            var result = orderby.ApplyOrderBy(users);
+            Assert.Equal(orderedIds, result.Select(i => i.Id).ToList());
+        }
     }
 }

--- a/Domain/RDD.Domain/Models/Querying/OrderBy.cs
+++ b/Domain/RDD.Domain/Models/Querying/OrderBy.cs
@@ -1,4 +1,4 @@
-﻿using Rdd.Domain.Helpers.Expressions;
+using Rdd.Domain.Helpers.Expressions;
 using System;
 using System.Linq;
 using System.Linq.Expressions;
@@ -10,19 +10,18 @@ namespace Rdd.Domain.Models.Querying
     public class OrderBy<T>
         where T : class
     {
-        public IExpression Expression { get; }
+        public LambdaExpression LambdaExpression { get; }
         public SortDirection Direction { get; }
 
-        public static OrderBy<T> New<TProp>(Expression<Func<T, TProp>> expression, SortDirection direction = SortDirection.Ascending)
-            => new OrderBy<T>(new PropertyExpression { LambdaExpression = expression }, direction);
         public static OrderBy<T> Ascending<TProp>(Expression<Func<T, TProp>> expression)
-            => new OrderBy<T>(new PropertyExpression { LambdaExpression = expression }, SortDirection.Ascending);
-        public static OrderBy<T> Descending<TProp>(Expression<Func<T, TProp>> expression)
-            => new OrderBy<T>(new PropertyExpression { LambdaExpression = expression }, SortDirection.Descending);
+            => new OrderBy<T>(expression, SortDirection.Ascending);
 
-        public OrderBy(IExpression expression, SortDirection direction = SortDirection.Ascending)
+        public static OrderBy<T> Descending<TProp>(Expression<Func<T, TProp>> expression)
+            => new OrderBy<T>(expression, SortDirection.Descending);
+
+        public OrderBy(LambdaExpression lambdaExpression, SortDirection direction = SortDirection.Ascending)
         {
-            Expression = expression;
+            LambdaExpression = lambdaExpression;
             Direction = direction;
         }
 
@@ -31,13 +30,26 @@ namespace Rdd.Domain.Models.Querying
             //https://www.tabsoverspaces.com/229310-sorting-in-iqueryable-using-string-as-column-name?utm_source=blog.cincura.net
             //https://stackoverflow.com/questions/3138133/what-is-the-purpose-of-linqs-expression-quote-method
 
-            var sort = Expression.ToLambdaExpression();
             var anotherLevel = typeof(IOrderedQueryable).IsAssignableFrom(source.Expression.Type)
                 && !typeof(EnumerableQuery).IsAssignableFrom(source.Expression.Type);
             var methodName = (!anotherLevel ? "OrderBy" : "ThenBy") + (Direction == SortDirection.Descending ? "Descending" : string.Empty);
-            var call = System.Linq.Expressions.Expression.Call(typeof(Queryable), methodName, new[] { typeof(T), Expression.ResultType }, source.Expression, System.Linq.Expressions.Expression.Quote(sort));
+            var correctedExpression = CorrectExpression();
+            var call = Expression.Call(typeof(Queryable), methodName, new[] { typeof(T), correctedExpression.ReturnType }, source.Expression, Expression.Quote(correctedExpression));
 
             return (IOrderedQueryable<T>)source.Provider.CreateQuery<T>(call);
+        }
+
+        protected virtual LambdaExpression CorrectExpression()
+        {
+            if (LambdaExpression.ReturnType != typeof(Guid) && LambdaExpression.ReturnType != typeof(Guid?))
+            {
+                return LambdaExpression;
+            }
+
+            //https://github.com/aspnet/EntityFrameworkCore/issues/10198
+            var method = LambdaExpression.ReturnType.GetMethod(nameof(Guid.ToString), new Type[] { });
+            var call = Expression.Call(LambdaExpression.Body, method);
+            return Expression.Lambda(call, LambdaExpression.Parameters[0]);
         }
     }
 }

--- a/Infra/RDD.Infra.Tests/CollectionTests.cs
+++ b/Infra/RDD.Infra.Tests/CollectionTests.cs
@@ -1,7 +1,8 @@
-﻿using Rdd.Domain.Models.Querying;
+using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Tests;
 using Rdd.Domain.Tests.Models;
 using Rdd.Infra.Storage;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -25,20 +26,36 @@ namespace Rdd.Infra.Tests
                 var repo = new UsersRepository(storage, _fixture.RightsService);
                 var collection = new UsersCollection(repo, _fixture.PatcherProvider, _fixture.Instanciator);
                 var users = User.GetManyRandomUsers(20).OrderBy(u => u.Id).ToList();
-                var firstUser = users.ElementAt(0);
-                var tenthUser = users.ElementAt(9);
-                var lastUser = users.ElementAt(19);
                 repo.AddRange(users);
                 await storage.SaveChangesAsync();
+
+                var sequence = users.Select(i => i.Id).ToList();
+
                 var result = (await collection.GetAsync(new Query<User>())).Items.ToList();
 
-                var firstItem = result.ElementAt(0);
-                var tenthItem = result.ElementAt(9);
-                var lastItem = result.ElementAt(19);
+                Assert.Equal(sequence, result.Select(i => i.Id).ToList());
+            });
+        }
 
-                Assert.Equal(firstUser, firstItem);
-                Assert.Equal(tenthUser, tenthItem);
-                Assert.Equal(lastUser, lastItem);
+        [Fact]
+        public async void NullableGuids_ordering_in_sql_should_work_properly()
+        {
+            await RunCodeInsideIsolatedDatabaseAsync(async (context) =>
+            {
+                var storage = new EFStorageService(context);
+                var repo = new UsersRepository(storage, _fixture.RightsService);
+                var collection = new UsersCollection(repo, _fixture.PatcherProvider, _fixture.Instanciator);
+
+                var users = User.GetManyRandomUsers(20).OrderBy(u => u.FriendId).ThenBy(u => u.Id).ToList();
+                repo.AddRange(users);
+                await storage.SaveChangesAsync();
+
+                var sequence = users.Select(i => i.Id).ToList();
+
+                var query = new Query<User> { OrderBys = new List<OrderBy<User>> { OrderBy<User>.Ascending(u => u.FriendId), OrderBy<User>.Ascending(u => u.Id) } };
+                var result = (await collection.GetAsync(query)).Items.ToList();
+
+                Assert.Equal(sequence, result.Select(i => i.Id).ToList());
             });
         }
     }

--- a/Infra/RDD.Infra.Tests/DatabaseTest.cs
+++ b/Infra/RDD.Infra.Tests/DatabaseTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Rdd.Domain.Tests.Models;
 using System;
 using System.Threading.Tasks;
@@ -15,6 +16,7 @@ namespace Rdd.Infra.Tests
         {
             return new DbContextOptionsBuilder<DataContext>()
                 .UseSqlServer($@"Server=(localdb)\mssqllocaldb;Database={dbName};Trusted_Connection=True;ConnectRetryCount=0")
+                .ConfigureWarnings(warnings => warnings.Throw(RelationalEventId.QueryClientEvaluationWarning))
                 .Options;
         }
 

--- a/Infra/RDD.Infra.Tests/UsersRepository.cs
+++ b/Infra/RDD.Infra.Tests/UsersRepository.cs
@@ -15,7 +15,9 @@ namespace Rdd.Infra.Tests
         {
             if (!query.OrderBys.Any())
             {
-                return entities.OrderBy(u => u.Id.ToString());
+                var orderById = OrderBy<User>.Ascending(u => u.Id);
+
+                return orderById.ApplyOrderBy(entities);
             }
 
             return base.ApplyOrderBys(entities, query);

--- a/Web/RDD.Web/Querying/OrderByParser.cs
+++ b/Web/RDD.Web/Querying/OrderByParser.cs
@@ -35,7 +35,7 @@ namespace Rdd.Web.Querying
 
                     if (orderDirection == "asc" || orderDirection == "desc")
                     {
-                        queue.Add(new OrderBy<TEntity>(orderProperty, orderDirection == "desc" ? SortDirection.Descending : SortDirection.Ascending));
+                        queue.Add(new OrderBy<TEntity>(orderProperty.ToLambdaExpression(), orderDirection == "desc" ? SortDirection.Descending : SortDirection.Ascending));
                     }
                     else
                     {


### PR DESCRIPTION
Le nouveau test plante à cause du .ToString()

Si on l'enlève alors le TU passe

Mais l'autre test, celui qui ne passe pas, correspond à un order by sur un Guid (uniqueidentifier en SQL) qui ne fonctionne pas en SQL, et pour cause, un "order by id asc" en SQL sur des GUID ne marche pas, même en faisant une req SQL directe.

D'où la nécessité du .ToString() en LINQ qui va convertir en string en SQL et le order by SQL fonctionne alors.

PS : si on peut corriger facilement tant mieux, sinon on peut mettre un gros warning comme quoi ça sert à rien d'essayer de trier sur des Guid => la classe OrderBy pourrait même planter explicitement si on lui demande de trier sur des Guid, c'est une alternative possible.