### PR TITLE
fix method lacks 'await' operators

### DIFF
--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -25,7 +25,7 @@ namespace RDD.Domain.Models
             Instanciator = instanciator;
         }
 
-        public virtual Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null)
+        public virtual async Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null)
         {
             TEntity entity = Instanciator.InstanciateNew(candidate);
 
@@ -33,14 +33,14 @@ namespace RDD.Domain.Models
 
             ForgeEntity(entity);
 
-            ValidateEntity(entity, null);
+            await ValidateEntityAsync(entity, null);
 
             Repository.Add(entity);
 
-            return Task.FromResult(entity);
+            return entity;
         }
 
-        public virtual Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query = null)
+        public virtual async Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query = null)
         {
             var result = new List<TEntity>();
 
@@ -52,14 +52,14 @@ namespace RDD.Domain.Models
 
                 ForgeEntity(entity);
 
-                ValidateEntity(entity, null);
+                await ValidateEntityAsync(entity, null);
 
                 result.Add(entity);
             }
 
             Repository.AddRange(result);
 
-            return Task.FromResult((IEnumerable<TEntity>)result);
+            return result;
         }
 
         public virtual async Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null)
@@ -118,7 +118,7 @@ namespace RDD.Domain.Models
 
         protected virtual void ForgeEntity(TEntity entity) { }
 
-        protected virtual void ValidateEntity(TEntity entity, TEntity oldEntity) { }
+        protected virtual Task ValidateEntityAsync(TEntity entity, TEntity oldEntity) => Task.CompletedTask;
 
         protected virtual Task OnBeforeUpdateEntity(TEntity entity, ICandidate<TEntity, TKey> candidate) => Task.CompletedTask;
 
@@ -139,7 +139,7 @@ namespace RDD.Domain.Models
 
             await OnAfterUpdateEntity(oldEntity, entity, candidate, query);
 
-            ValidateEntity(entity, oldEntity);
+            await ValidateEntityAsync(entity, oldEntity);
 
             return entity;
         }

--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -25,7 +25,7 @@ namespace RDD.Domain.Models
             Instanciator = instanciator;
         }
 
-        public virtual async Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null)
+        public virtual Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null)
         {
             TEntity entity = Instanciator.InstanciateNew(candidate);
 
@@ -37,10 +37,10 @@ namespace RDD.Domain.Models
 
             Repository.Add(entity);
 
-            return entity;
+            return Task.FromResult(entity);
         }
 
-        public virtual async Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query = null)
+        public virtual Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query = null)
         {
             var result = new List<TEntity>();
 
@@ -58,7 +58,8 @@ namespace RDD.Domain.Models
             }
 
             Repository.AddRange(result);
-            return result;
+
+            return Task.FromResult((IEnumerable<TEntity>)result);
         }
 
         public virtual async Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Futur release
 ## Breaking changes
+ - **Modification**: ValidateEntity on RestCollection is now ValidateEntityAsync
  - **Modification**: Multiple Put now returns a `ISelection` instead of enumerable
  - **Removed**: unused metadata.paging in returned json
  - **Removed**: `IRddSerializer`. replaced by a `RddJsonResult`.


### PR DESCRIPTION
warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.

