### PR TITLE
TreatWarningsAsErrors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <!-- <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningLevel>4</WarningLevel> -->
+     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningLevel>4</WarningLevel> 
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Prefer32Bit>false</Prefer32Bit>


### PR DESCRIPTION
Activation de l'option TreatWarningsAsErrors, permettant de fail un build si des warnings de compilation existent.

L'idée est de renforcer la qualité de code.

Nécessite de merger les PR suivantes auparavant : 
- https://github.com/LuccaSA/RestDrivenDomain/pull/188
- https://github.com/LuccaSA/RestDrivenDomain/pull/189
- https://github.com/LuccaSA/RestDrivenDomain/pull/190