### PR TITLE
FIX : utilsier le retour du patcher

### DIFF
--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -29,7 +29,7 @@ namespace Rdd.Domain.Models
         {
             TEntity entity = Instanciator.InstanciateNew(candidate);
 
-            Patcher.Patch(entity, candidate.JsonValue);
+            entity = Patcher.Patch(entity, candidate.JsonValue);
 
             ForgeEntity(entity);
 
@@ -48,7 +48,7 @@ namespace Rdd.Domain.Models
             {
                 TEntity entity = Instanciator.InstanciateNew(candidate);
 
-                Patcher.Patch(entity, candidate.JsonValue);
+                entity = Patcher.Patch(entity, candidate.JsonValue);
 
                 ForgeEntity(entity);
 
@@ -135,7 +135,7 @@ namespace Rdd.Domain.Models
 
             TEntity oldEntity = entity.Clone();
 
-            Patcher.Patch(entity, candidate.JsonValue);
+            entity = Patcher.Patch(entity, candidate.JsonValue);
 
             await OnAfterUpdateEntity(oldEntity, entity, candidate, query);
 


### PR DESCRIPTION
popleetalent a besoin d'avoir le retour du patcher, notamment quand l'objet patché est en réalité transmuté ou carrément jeté/regénéré