### PR TITLE
MOD : Ientitybase light pass

### DIFF
--- a/Application/RDD.Application/Controllers/AppController.cs
+++ b/Application/RDD.Application/Controllers/AppController.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Rdd.Application.Controllers
 {
     public class AppController<TEntity, TKey> : AppController<IRestCollection<TEntity, TKey>, TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>
+        where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
         public AppController(IUnitOfWork unitOfWork, IRestCollection<TEntity, TKey> collection)
@@ -18,7 +18,7 @@ namespace Rdd.Application.Controllers
 
     public class AppController<TCollection, TEntity, TKey> : ReadOnlyAppController<TCollection, TEntity, TKey>, IAppController<TEntity, TKey>
         where TCollection : IRestCollection<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>
+        where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
         protected IUnitOfWork UnitOfWork { get; }

--- a/Application/RDD.Application/IAppController.cs
+++ b/Application/RDD.Application/IAppController.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Rdd.Application
 {
     public interface IAppController<TEntity, TKey> : IReadOnlyAppController<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>
+        where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
         Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query);

--- a/Domain/RDD.Domain.Mocks/Hierarchy.cs
+++ b/Domain/RDD.Domain.Mocks/Hierarchy.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Rdd.Domain.Mocks
 {
-    public abstract class Hierarchy : IEntityBase<Hierarchy, int>
+    public abstract class Hierarchy : IEntityBase<int>
     {
         public string BaseProperty { get; set; }
 

--- a/Domain/RDD.Domain.Tests/Models/DataContext.cs
+++ b/Domain/RDD.Domain.Tests/Models/DataContext.cs
@@ -17,15 +17,13 @@ namespace Rdd.Domain.Tests.Models
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<ConcreteClassThree>().Ignore(c => c.Url);
+            modelBuilder.Entity<ConcreteClassThree>();
+
+            modelBuilder.Entity<AbstractClass>();
             
-            modelBuilder.Entity<AbstractClass>().Ignore(a => a.Url);
-            
-            modelBuilder.Entity<User>().Ignore(u => u.Url);
             modelBuilder.Entity<User>().Ignore(u => u.Mail);
             modelBuilder.Entity<User>().Ignore(u => u.TwitterUri);
 
-            modelBuilder.Entity<UserWithParameters>().Ignore(u => u.Url);
             modelBuilder.Entity<UserWithParameters>().Ignore(u => u.Mail);
             modelBuilder.Entity<UserWithParameters>().Ignore(u => u.TwitterUri);
 

--- a/Domain/RDD.Domain.Tests/Models/TablePerHierarchyModel.cs
+++ b/Domain/RDD.Domain.Tests/Models/TablePerHierarchyModel.cs
@@ -2,19 +2,10 @@
 
 namespace Rdd.Domain.Tests.Models
 {
-    public abstract class AbstractClass : EntityBase<int>
-    {
-        public override int Id { get; set; }
-
-        public override string Name { get; set; }
-    }
+    public abstract class AbstractClass : EntityBase<int> { }
 
     public class ConcreteClassOne : AbstractClass { }
     public class ConcreteClassTwo : AbstractClass { }
 
-    public class ConcreteClassThree : EntityBase<int>
-    {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
-    }
+    public class ConcreteClassThree : EntityBase<int> { }
 }

--- a/Domain/RDD.Domain.Tests/Models/TablePerHierarchyModel.cs
+++ b/Domain/RDD.Domain.Tests/Models/TablePerHierarchyModel.cs
@@ -2,7 +2,7 @@
 
 namespace Rdd.Domain.Tests.Models
 {
-    public abstract class AbstractClass : EntityBase<AbstractClass, int>
+    public abstract class AbstractClass : EntityBase<int>
     {
         public override int Id { get; set; }
 
@@ -12,7 +12,7 @@ namespace Rdd.Domain.Tests.Models
     public class ConcreteClassOne : AbstractClass { }
     public class ConcreteClassTwo : AbstractClass { }
 
-    public class ConcreteClassThree : EntityBase<ConcreteClassThree, int>
+    public class ConcreteClassThree : EntityBase<int>
     {
         public override int Id { get; set; }
         public override string Name { get; set; }

--- a/Domain/RDD.Domain.Tests/Models/User.cs
+++ b/Domain/RDD.Domain.Tests/Models/User.cs
@@ -5,7 +5,7 @@ using System.Net.Mail;
 
 namespace Rdd.Domain.Tests.Models
 {
-    public class User : EntityBase<User, Guid>
+    public class User : EntityBase<Guid>
     {
         public override Guid Id { get; set; }
         public override string Name { get; set; }

--- a/Domain/RDD.Domain.Tests/Models/User.cs
+++ b/Domain/RDD.Domain.Tests/Models/User.cs
@@ -7,8 +7,6 @@ namespace Rdd.Domain.Tests.Models
 {
     public class User : EntityBase<Guid>
     {
-        public override Guid Id { get; set; }
-        public override string Name { get; set; }
         public MailAddress Mail { get; set; }
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }

--- a/Domain/RDD.Domain.Tests/Models/UserWithParameters.cs
+++ b/Domain/RDD.Domain.Tests/Models/UserWithParameters.cs
@@ -5,7 +5,7 @@ using System.Net.Mail;
 
 namespace Rdd.Domain.Tests.Models
 {
-    public class UserWithParameters : EntityBase<UserWithParameters, int>
+    public class UserWithParameters : EntityBase<int>
     {
         public override int Id { get; set; }
         public override string Name { get; set; }

--- a/Domain/RDD.Domain.Tests/Models/UserWithParameters.cs
+++ b/Domain/RDD.Domain.Tests/Models/UserWithParameters.cs
@@ -7,8 +7,6 @@ namespace Rdd.Domain.Tests.Models
 {
     public class UserWithParameters : EntityBase<int>
     {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
         public MailAddress Mail { get; set; }
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }

--- a/Domain/RDD.Domain/IEntityBase.cs
+++ b/Domain/RDD.Domain/IEntityBase.cs
@@ -7,6 +7,4 @@
     }
 
     public interface IEntityBase<TKey> : IEntityBase, IPrimaryKey<TKey> { }
-
-    public interface IEntityBase<TEntity, TKey> : IEntityBase<TKey>{ }
 }

--- a/Domain/RDD.Domain/IPrimaryKey.cs
+++ b/Domain/RDD.Domain/IPrimaryKey.cs
@@ -3,7 +3,6 @@
     public interface IPrimaryKey
     {
         object GetId();
-        void SetId(object id);
     }
 
     public interface IPrimaryKey<out TKey> : IPrimaryKey

--- a/Domain/RDD.Domain/Models/EntityBase.cs
+++ b/Domain/RDD.Domain/Models/EntityBase.cs
@@ -6,8 +6,8 @@ namespace Rdd.Domain.Models
     public abstract class EntityBase<TKey> : IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
-        public abstract TKey Id { get; set; }
-        public abstract string Name { get; set; }
+        public virtual TKey Id { get; set; }
+        public virtual string Name { get; set; }
 
         [NotMapped]
         public virtual string Url { get; set; }

--- a/Domain/RDD.Domain/Models/EntityBase.cs
+++ b/Domain/RDD.Domain/Models/EntityBase.cs
@@ -1,17 +1,17 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Rdd.Domain.Models
 {
-    public abstract class EntityBase<TEntity, TKey> : IEntityBase<TEntity, TKey>
-        where TEntity : class
+    public abstract class EntityBase<TKey> : IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
         public abstract TKey Id { get; set; }
         public abstract string Name { get; set; }
-        public string Url { get; set; }
+
+        [NotMapped]
+        public virtual string Url { get; set; }
 
         public virtual object GetId() => Id;
-
-        public virtual void SetId(object id) => Id = (TKey)id;
     }
 }

--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace Rdd.Domain.Models
 {
     public class RestCollection<TEntity, TKey> : ReadOnlyRestCollection<TEntity, TKey>, IRestCollection<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>
+        where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
         protected new IRepository<TEntity> Repository { get; set; }

--- a/Infra/RDD.Infra/Storage/InMemoryStorageService.cs
+++ b/Infra/RDD.Infra/Storage/InMemoryStorageService.cs
@@ -90,24 +90,6 @@ namespace Rdd.Infra.Storage
 
         public Task SaveChangesAsync()
         {
-            foreach (var type in Cache.Keys)
-            {
-                var index = Indexes[type];
-
-                foreach (var element in Cache[type])
-                {
-                    var entity = (IPrimaryKey)element;
-                    var id = entity.GetId().ToString();
-
-                    if (id == 0.ToString())
-                    {
-                        entity.SetId(++index);
-                    }
-                }
-
-                Indexes[type] = index;
-            }
-
             return Task.CompletedTask;
         }
 

--- a/Web/RDD.Web.Tests/Models/AnotherUser.cs
+++ b/Web/RDD.Web.Tests/Models/AnotherUser.cs
@@ -2,7 +2,7 @@
 
 namespace Rdd.Web.Tests.Models
 {
-    public class AnotherUser : EntityBase<IUser, int>, IUser
+    public class AnotherUser : EntityBase<int>, IUser
     {
         public override int Id { get; set; }
         public override string Name { get; set; }

--- a/Web/RDD.Web.Tests/Models/AnotherUser.cs
+++ b/Web/RDD.Web.Tests/Models/AnotherUser.cs
@@ -2,9 +2,5 @@
 
 namespace Rdd.Web.Tests.Models
 {
-    public class AnotherUser : EntityBase<int>, IUser
-    {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
-    }
+    public class AnotherUser : EntityBase<int>, IUser { }
 }

--- a/Web/RDD.Web.Tests/Models/Department.cs
+++ b/Web/RDD.Web.Tests/Models/Department.cs
@@ -7,8 +7,6 @@ namespace Rdd.Web.Tests.Models
     public enum Test { A = 0, B = 10 }
     public class Department : EntityBase<int>
     {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
         public ICollection<User> Users { get; set; }
 
         public Test? Enum { get; set; }

--- a/Web/RDD.Web.Tests/Models/Department.cs
+++ b/Web/RDD.Web.Tests/Models/Department.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 
 namespace Rdd.Web.Tests.Models
 {
+    
     public enum Test { A = 0, B = 10 }
-    public class Department : EntityBase<Department, int>
+    public class Department : EntityBase<int>
     {
         public override int Id { get; set; }
         public override string Name { get; set; }

--- a/Web/RDD.Web.Tests/Models/IUser.cs
+++ b/Web/RDD.Web.Tests/Models/IUser.cs
@@ -2,7 +2,7 @@
 
 namespace Rdd.Web.Tests.Models
 {
-    public interface IUser : IEntityBase<IUser, int>
+    public interface IUser : IEntityBase<int>
     {
     }
 }

--- a/Web/RDD.Web.Tests/Models/User.cs
+++ b/Web/RDD.Web.Tests/Models/User.cs
@@ -1,10 +1,9 @@
-﻿using Rdd.Domain;
-using Rdd.Domain.Models;
+﻿using Rdd.Domain.Models;
 using System;
 
 namespace Rdd.Web.Tests.Models
 {
-    public class User : EntityBase<User, int>, IUser
+    public class User : EntityBase<int>, IUser
     {
         public override int Id { get; set; }
         public override string Name { get; set; }

--- a/Web/RDD.Web.Tests/Models/User.cs
+++ b/Web/RDD.Web.Tests/Models/User.cs
@@ -5,8 +5,6 @@ namespace Rdd.Web.Tests.Models
 {
     public class User : EntityBase<int>, IUser
     {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
         public MyValueObject MyValueObject { get; set; }
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }

--- a/Web/RDD.Web.Tests/ServerMock/ExchangeRate.cs
+++ b/Web/RDD.Web.Tests/ServerMock/ExchangeRate.cs
@@ -2,7 +2,7 @@ using Rdd.Domain.Models;
 
 namespace Rdd.Web.Tests.ServerMock
 {
-    public class ExchangeRate : EntityBase<ExchangeRate, int>
+    public class ExchangeRate : EntityBase<int>
     {
         public override int Id { get; set; }
         public override string Name { get; set; }

--- a/Web/RDD.Web.Tests/ServerMock/ExchangeRate.cs
+++ b/Web/RDD.Web.Tests/ServerMock/ExchangeRate.cs
@@ -2,9 +2,5 @@ using Rdd.Domain.Models;
 
 namespace Rdd.Web.Tests.ServerMock
 {
-    public class ExchangeRate : EntityBase<int>
-    {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
-    }
+    public class ExchangeRate : EntityBase<int> { }
 }

--- a/Web/RDD.Web.Tests/Services/ServicesCollectionTests.cs
+++ b/Web/RDD.Web.Tests/Services/ServicesCollectionTests.cs
@@ -22,7 +22,7 @@ namespace Rdd.Web.Tests.Services
 {
     public class ServicesCollectionTests
     {
-        public abstract class Hierarchy2 : IEntityBase<Hierarchy2, int>
+        public abstract class Hierarchy2 : IEntityBase<int>
         {
             public string Name { get; set; }
             public string Url { get; set; }

--- a/Web/RDD.Web/Controllers/ReadOnlyWebController.cs
+++ b/Web/RDD.Web/Controllers/ReadOnlyWebController.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 namespace Rdd.Web.Controllers
 {
     public abstract class ReadOnlyWebController<TEntity, TKey> : ReadOnlyWebController<IReadOnlyAppController<TEntity, TKey>, TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>
+        where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
         protected ReadOnlyWebController(IReadOnlyAppController<TEntity, TKey> appController, ApiHelper<TEntity, TKey> helper)
@@ -24,7 +24,7 @@ namespace Rdd.Web.Controllers
     [ApiExplorerSettings(IgnoreApi = true)]
     public abstract class ReadOnlyWebController<TAppController, TEntity, TKey> : ControllerBase
         where TAppController : IReadOnlyAppController<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>
+        where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
         protected TAppController AppController { get; }

--- a/Web/RDD.Web/Controllers/WebController.cs
+++ b/Web/RDD.Web/Controllers/WebController.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 namespace Rdd.Web.Controllers
 {
     public abstract class WebController<TEntity, TKey> : WebController<IAppController<TEntity, TKey>, TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>
+        where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
         protected WebController(IAppController<TEntity, TKey> appController, ApiHelper<TEntity, TKey> helper)
@@ -26,7 +26,7 @@ namespace Rdd.Web.Controllers
 
     public abstract class WebController<TAppController, TEntity, TKey> : ReadOnlyWebController<TAppController, TEntity, TKey>
         where TAppController : IAppController<TEntity, TKey>
-        where TEntity : class, IEntityBase<TEntity, TKey>
+        where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
 

--- a/Web/RDD.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/Web/RDD.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -67,7 +67,7 @@ namespace Rdd.Web.Helpers
 
         public static IServiceCollection AddRddInheritanceConfiguration<TConfig, TEntity, TKey>(this IServiceCollection services, TConfig config)
             where TConfig : class, IInheritanceConfiguration<TEntity>
-            where TEntity : class, IEntityBase<TEntity, TKey>
+            where TEntity : class, IEntityBase<TKey>
             where TKey : IEquatable<TKey>
         {
             services.AddSingleton<IInheritanceConfiguration>(s => config);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@
  - **Modification**: Patchers now use ``IReflectionHelper``, are public and registered for performances boost.
  - **Removed**: unused classes `ExpressionHelper` and `NameValueCollectionHelper`
  - **Removed**: `IClonable<>` interface & ``Clone()`` method
+ - **Removed**: `IEntityBase<TEntity, TKey>`, `EntityBase<TEntity, TKey>` and usages. This can be directly replaced by `IEntityBase<TKey>` or `EntityBase<TKey>`.
+ - **Removed**: ``IPrimaryKey.SetId()``
+ - **Modification**: ``EntityBase<TKey>.Url`` has attribute `NotMapped`
  - **Removed**: `Query<TEntity> query` parameter removed from prototype of ``ReadOnlyRepository.Set()`` method 
  - **Modification**: ``ValidateEntity`` on RestCollection is now ``ValidateEntityAsync``
  - **Modification**: ``AppController`` now depends on a `IUnitOfWork`.


### PR DESCRIPTION
Je propose trois petites modifications liées à l'interface Ientitybase:

 - **Removed**: `IEntityBase<TEntity, TKey>`, `EntityBase<TEntity, TKey>` and usages. This can be directly replaced by `IEntityBase<TKey>` or `EntityBase<TKey>`. Cela est vrai depuis qu'on a drop les fonctionalités concernant le clonage
 - **Removed**: ``IPrimaryKey.SetId()`` pas utilisé, et permet de garder l'objet readonly
 - **Modification**: ``EntityBase<TKey>.Url`` has attribute `NotMapped` . Je propose de rajouter cet attribut `System.ComponentModel.DataAnnotations.Schema` pour ne pas avoir à le rajouter sur chaque déclaration de type EF.