### PR TITLE
MOD : EntityBase propose désormais une implémentation par défaut pour…

### DIFF
--- a/Domain/RDD.Domain.Tests/Models/TablePerHierarchyModel.cs
+++ b/Domain/RDD.Domain.Tests/Models/TablePerHierarchyModel.cs
@@ -2,19 +2,10 @@
 
 namespace Rdd.Domain.Tests.Models
 {
-    public abstract class AbstractClass : EntityBase<int>
-    {
-        public override int Id { get; set; }
-
-        public override string Name { get; set; }
-    }
+    public abstract class AbstractClass : EntityBase<int> { }
 
     public class ConcreteClassOne : AbstractClass { }
     public class ConcreteClassTwo : AbstractClass { }
 
-    public class ConcreteClassThree : EntityBase<int>
-    {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
-    }
+    public class ConcreteClassThree : EntityBase<int> { }
 }

--- a/Domain/RDD.Domain.Tests/Models/User.cs
+++ b/Domain/RDD.Domain.Tests/Models/User.cs
@@ -7,8 +7,6 @@ namespace Rdd.Domain.Tests.Models
 {
     public class User : EntityBase<Guid>
     {
-        public override Guid Id { get; set; }
-        public override string Name { get; set; }
         public MailAddress Mail { get; set; }
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }

--- a/Domain/RDD.Domain.Tests/Models/UserWithParameters.cs
+++ b/Domain/RDD.Domain.Tests/Models/UserWithParameters.cs
@@ -7,8 +7,6 @@ namespace Rdd.Domain.Tests.Models
 {
     public class UserWithParameters : EntityBase<int>
     {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
         public MailAddress Mail { get; set; }
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }

--- a/Domain/RDD.Domain/Models/EntityBase.cs
+++ b/Domain/RDD.Domain/Models/EntityBase.cs
@@ -6,8 +6,8 @@ namespace Rdd.Domain.Models
     public abstract class EntityBase<TKey> : IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
-        public abstract TKey Id { get; set; }
-        public abstract string Name { get; set; }
+        public virtual TKey Id { get; set; }
+        public virtual string Name { get; set; }
 
         [NotMapped]
         public virtual string Url { get; set; }

--- a/Web/RDD.Web.Tests/Models/AnotherUser.cs
+++ b/Web/RDD.Web.Tests/Models/AnotherUser.cs
@@ -2,9 +2,5 @@
 
 namespace Rdd.Web.Tests.Models
 {
-    public class AnotherUser : EntityBase<int>, IUser
-    {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
-    }
+    public class AnotherUser : EntityBase<int>, IUser { }
 }

--- a/Web/RDD.Web.Tests/Models/Department.cs
+++ b/Web/RDD.Web.Tests/Models/Department.cs
@@ -5,8 +5,6 @@ namespace Rdd.Web.Tests.Models
 {
     public class Department : EntityBase<int>
     {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
         public ICollection<User> Users { get; set; }
 
         public Department()

--- a/Web/RDD.Web.Tests/Models/User.cs
+++ b/Web/RDD.Web.Tests/Models/User.cs
@@ -5,8 +5,6 @@ namespace Rdd.Web.Tests.Models
 {
     public class User : EntityBase<int>, IUser
     {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
         public MyValueObject MyValueObject { get; set; }
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }

--- a/Web/RDD.Web.Tests/ServerMock/ExchangeRate.cs
+++ b/Web/RDD.Web.Tests/ServerMock/ExchangeRate.cs
@@ -2,9 +2,5 @@ using Rdd.Domain.Models;
 
 namespace Rdd.Web.Tests.ServerMock
 {
-    public class ExchangeRate : EntityBase<int>
-    {
-        public override int Id { get; set; }
-        public override string Name { get; set; }
-    }
+    public class ExchangeRate : EntityBase<int> { }
 }


### PR DESCRIPTION
… Id, Name.

J'ai essayé de virer le set; de Name mais ça n'est pas possible. Si dans un projet on ne veut pas imposer le set; de Name il faut implémenter IEntityBase plutôt que dériver de EntityBase.