### PR TITLE
Validation consistency

### DIFF
--- a/Domain/RDD.Domain/IRepository.cs
+++ b/Domain/RDD.Domain/IRepository.cs
@@ -8,5 +8,6 @@ namespace Rdd.Domain
         void Add(TEntity entity);
         void AddRange(IEnumerable<TEntity> entities);
         void Remove(TEntity entity);
+        void DiscardChanges(TEntity entity);
     }
 }

--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -123,22 +123,22 @@ namespace Rdd.Domain.Models
 
         private async Task<bool> ValidateOrDiscardAsync(TEntity entity)
         {
-            bool isValid;
+            bool isValid = false;
             try
             {
                 isValid = await ValidateEntityAsync(entity);
             }
             catch (Exception)
             {
-                Repository.DiscardChanges(entity);
                 throw;
             }
-
-            if (!isValid)
+            finally
             {
-                Repository.DiscardChanges(entity);
+                if (!isValid)
+                {
+                    Repository.DiscardChanges(entity);
+                }
             }
-
             return isValid;
         }
 

--- a/Domain/RDD.Domain/Models/RestCollection.cs
+++ b/Domain/RDD.Domain/Models/RestCollection.cs
@@ -128,10 +128,6 @@ namespace Rdd.Domain.Models
             {
                 isValid = await ValidateEntityAsync(entity);
             }
-            catch (Exception)
-            {
-                throw;
-            }
             finally
             {
                 if (!isValid)

--- a/Infra/RDD.Infra/Storage/IStorageService.cs
+++ b/Infra/RDD.Infra/Storage/IStorageService.cs
@@ -12,5 +12,6 @@ namespace Rdd.Infra.Storage
         void Add<TEntity>(TEntity entity) where TEntity : class;
         void AddRange<TEntity>(IEnumerable<TEntity> entities) where TEntity : class;
         void Remove<TEntity>(TEntity entity) where TEntity : class;
+        void DiscardChanges<TEntity>(TEntity entity) where TEntity : class;
     }
 }

--- a/Infra/RDD.Infra/Storage/InMemoryStorageService.cs
+++ b/Infra/RDD.Infra/Storage/InMemoryStorageService.cs
@@ -70,6 +70,11 @@ namespace Rdd.Infra.Storage
             Cache[typeof(TEntity)].Remove(entity);
         }
 
+        public void DiscardChanges<TEntity>(TEntity entity) where TEntity : class
+        {
+            throw new NotImplementedException();
+        }
+
         public void AddRange<TEntity>(IEnumerable<TEntity> entities)
             where TEntity : class
         {

--- a/Infra/RDD.Infra/Storage/Repository.cs
+++ b/Infra/RDD.Infra/Storage/Repository.cs
@@ -25,5 +25,10 @@ namespace Rdd.Infra.Storage
         {
             StorageService.Remove(entity);
         }
+
+        public void DiscardChanges(TEntity entity)
+        {
+            StorageService.DiscardChanges(entity);
+        }
     }
 }

--- a/Web/Rdd.Web.Tests/ValidationTests.cs
+++ b/Web/Rdd.Web.Tests/ValidationTests.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Rdd.Domain;
+using Rdd.Domain.Models;
+using Rdd.Domain.Models.Querying;
+using Rdd.Domain.Patchers;
+using Rdd.Web.Helpers;
+using Rdd.Web.Models;
+using Rdd.Web.Tests.ServerMock;
+using Xunit;
+
+namespace Rdd.Web.Tests
+{
+    public class ValidationTests
+    {
+        [Theory]
+        [InlineData(typeof(RestCollection<,>), true)]
+        [InlineData(typeof(ValidationOkCollection<,>), true)]
+        [InlineData(typeof(ValidationFailCollection<,>), false)]
+        [InlineData(typeof(ValidationThrowCollection<,>), false)]
+        [InlineData(typeof(ValidationThrowAsyncCollection<,>), false)]
+        public async Task ValidOk(Type collectionType, bool modificationExpected)
+        {
+            // arrange
+            var services = new ServiceCollection();
+            services.AddRdd<ExchangeRateDbContext, CombinationsHolder, CurPrincipal>();
+            services.AddDbContext<ExchangeRateDbContext>((service, options) => { options.UseInMemoryDatabase("validation"); });
+            services.AddScoped(typeof(IRestCollection<,>), collectionType);
+            var provider = services.BuildServiceProvider();
+
+            var dbContext = provider.GetRequiredService<DbContext>();
+            dbContext.Add(new ExchangeRate { Id = 42, Name = "42" });
+            await dbContext.SaveChangesAsync();
+
+            // act
+            var collection = provider.GetRequiredService<IRestCollection<ExchangeRate, int>>();
+
+            var candidate = Candidate<ExchangeRate, int>.Parse(@"{ ""name"": ""something""}");
+
+            ExchangeRate ok;
+            try
+            {
+                ok = await collection.UpdateByIdAsync(42, candidate, new Query<ExchangeRate>());
+            }
+            catch (Exception)
+            {
+                ok = await collection.GetByIdAsync(42, new Query<ExchangeRate>());
+            }
+
+            // assert
+            if (modificationExpected)
+            {
+                Assert.Equal("something", ok.Name);
+            }
+            else
+            {
+                Assert.Equal("42", ok.Name);
+            }
+        }
+
+        public class ValidationFailCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TEntity, TKey> where TKey : IEquatable<TKey>
+        {
+            public ValidationFailCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
+                : base(repository, patcher, instanciator) { }
+
+            protected override Task<bool> ValidateEntityAsync(TEntity entity) => Task.FromResult(false);
+        }
+
+        public class ValidationOkCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TEntity, TKey> where TKey : IEquatable<TKey>
+        {
+            public ValidationOkCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
+                : base(repository, patcher, instanciator) { }
+
+            protected override Task<bool> ValidateEntityAsync(TEntity entity) => Task.FromResult(true);
+        }
+
+        public class ValidationThrowCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TEntity, TKey> where TKey : IEquatable<TKey>
+        {
+            public ValidationThrowCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
+                : base(repository, patcher, instanciator) { }
+
+            protected override Task<bool> ValidateEntityAsync(TEntity entity) => throw new NotImplementedException();
+        }
+
+        public class ValidationThrowAsyncCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TEntity, TKey> where TKey : IEquatable<TKey>
+        {
+            public ValidationThrowAsyncCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
+                : base(repository, patcher, instanciator) { }
+
+            protected override async Task<bool> ValidateEntityAsync(TEntity entity)
+            {
+                await Task.Delay(1);
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Web/Rdd.Web.Tests/ValidationTests.cs
+++ b/Web/Rdd.Web.Tests/ValidationTests.cs
@@ -6,6 +6,7 @@ using Rdd.Domain;
 using Rdd.Domain.Models;
 using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Patchers;
+using Rdd.Domain.Rights;
 using Rdd.Web.Helpers;
 using Rdd.Web.Models;
 using Rdd.Web.Tests.ServerMock;
@@ -25,7 +26,10 @@ namespace Rdd.Web.Tests
         {
             // arrange
             var services = new ServiceCollection();
-            services.AddRdd<ExchangeRateDbContext, CombinationsHolder, CurPrincipal>();
+            services
+                .AddRdd<ExchangeRateDbContext>()
+                .WithDefaultRights(RightDefaultMode.Open);
+
             services.AddDbContext<ExchangeRateDbContext>((service, options) => { options.UseInMemoryDatabase("validation"); });
             services.AddScoped(typeof(IRestCollection<,>), collectionType);
             var provider = services.BuildServiceProvider();
@@ -60,7 +64,7 @@ namespace Rdd.Web.Tests
             }
         }
 
-        public class ValidationFailCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TEntity, TKey> where TKey : IEquatable<TKey>
+        public class ValidationFailCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
             public ValidationFailCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
                 : base(repository, patcher, instanciator) { }
@@ -68,7 +72,7 @@ namespace Rdd.Web.Tests
             protected override Task<bool> ValidateEntityAsync(TEntity entity) => Task.FromResult(false);
         }
 
-        public class ValidationOkCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TEntity, TKey> where TKey : IEquatable<TKey>
+        public class ValidationOkCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
             public ValidationOkCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
                 : base(repository, patcher, instanciator) { }
@@ -76,7 +80,7 @@ namespace Rdd.Web.Tests
             protected override Task<bool> ValidateEntityAsync(TEntity entity) => Task.FromResult(true);
         }
 
-        public class ValidationThrowCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TEntity, TKey> where TKey : IEquatable<TKey>
+        public class ValidationThrowCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
             public ValidationThrowCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
                 : base(repository, patcher, instanciator) { }
@@ -84,7 +88,7 @@ namespace Rdd.Web.Tests
             protected override Task<bool> ValidateEntityAsync(TEntity entity) => throw new NotImplementedException();
         }
 
-        public class ValidationThrowAsyncCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TEntity, TKey> where TKey : IEquatable<TKey>
+        public class ValidationThrowAsyncCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
             public ValidationThrowAsyncCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
                 : base(repository, patcher, instanciator) { }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Futur release
 ## Breaking changes
+ - **Modification**: ``ValidateEntity`` on RestCollection now is ``ValidateEntityAsync`` and returns a bool
+  - **Modification**: RestCollection now return null or empty collection if entity is not validated
  - **Removed**: `IPrincipal`. Rdd now uses current `ClaimsPrincipal`
  - **Removed**: Unused `UnreachableEntityException`, `RightExpressionsHelper`, `ICombinationsHolder`. Replaced by `Closed/OpenRightExpressionsHelper`. To correctly handle rights, please implement your version, or use external librairy (`Lucca.Core.Rights`).
  - **Modification**: `AddRddRights<TCombinationsHolder, TPrincipal>()` -> `AddRddDefaultRights(RightDefaultMode mode)`


### PR DESCRIPTION
## Problématique 

Lors de la validation, si une entité est invalide, alors actuellement nous devons `throw` une exception, ce depuis la couche `RestCollection`. Le cas d'utilisation rencontré, est le suivant : 

Si depuis la couche Application, on catch une exception particulière lors de l'override Update/Create, et qu'on ré-interroge le `DbContext` juste après en Get sur l'Id de l'entité que l'on a refusée en Update, alors on récupère la version modifiée de cette entité, et pas l'original. Ceci est du au fait que EF garde dans son contexte un cache local des entités.
Hors si un dev catch, une exception particulière puis poursuis, le `SaveChangesAsync()` sera appelé.

Le gros danger est donc que l'entité soit par la suite sauvegardée. Cette PR permet de donner une garantie forte qu'une entité invalide ne sera pas sauvegardée.

## Approche de la PR

Cette problématique avait été adressée sur la PR https://github.com/LuccaSA/RestDrivenDomain/pull/192 (non mergée) d'une façon différente en s'appuyant sur le Clone() des entités, que nous retirons.

Ici, cette PR utilise les méthodes standard de EF permettant de piloter la présence ou non d'une entité modifiée (ou créée / supprimée) dans la méthode `public void DiscardChanges<TEntity>(TEntity entity)`

On agit sur le `EntityState` de l'entité, ce qui provoque sa disparition du `DbContext`. Ainsi, un `SaveChangesAsync()` n'aura aucun effet sur cette entité.

Ici il s'agit je pense de l'approche la plus propre permettant de **garantir totalement** qu'on ne sauvegardera jamais une entité invalide via Rdd.

Second point : la méthode ValidateAsync permet désormais de retourner un booléen en plus du scénario "throw Exception", qui je pense est plus intuitif à implémenter : 

`protected virtual Task<bool> ValidateEntityAsync(TEntity entity)`

## Problématique annexe : 

Pour l'instant, le `InMemoryStorageService` n'implémente pas cette méthode, car pour ce faire, il faudrait lui rajouter une distinction entre les entités globales, et les entités en attente de `SaveChangesAsync()`.
Si nous implémentons cette feature, ce serait : 
- à la fois beaucoup plus réaliste et pertinent par rapport à l'infrastructure Rdd actuelle, car lors des tests les sauvegardes ne seraient effectuées que lors d'un `SaveChangesAsync()`
- et à la fois dans ce cas, je ne vois plus la différence entre un InMemoryStorageService et un contexte de test EF Core in-memory.

Personnellement, je penche fortement pour supprimer totalement `InMemoryStorageService`, car EF Core in-memory est extrêmement performant, et ses éveentuels effets de bord sont pertinents dans un contexte de test de Rdd ou d'une appli qui consomme Rdd.