### PR TITLE
Adds AppController AfterGet, BeforeSave and AfterSave methods

### DIFF
--- a/Application/RDD.Application/Controllers/AppController.cs
+++ b/Application/RDD.Application/Controllers/AppController.cs
@@ -23,74 +23,64 @@ namespace Rdd.Application.Controllers
         where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
-        protected IUnitOfWork UnitOfWork { get; }
+        private readonly IUnitOfWork _unitOfWork;
 
         public AppController(IUnitOfWork unitOfWork, TCollection collection)
             : base(collection)
         {
-            UnitOfWork = unitOfWork;
+            _unitOfWork = unitOfWork;
         }
 
         public virtual async Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query)
         {
             var entity = await Collection.CreateAsync(candidate, query);
-
-            await OnBeforeSaveEntitiesAsync(entity.Yield());
-            await UnitOfWork.SaveChangesAsync();
-            await OnAfterSaveEntitiesAsync(entity.Yield());
-
+            await SaveChangesAsync(entity.Yield());
             return entity;
         }
 
         public virtual async Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query)
         {
             var entities = await Collection.CreateAsync(candidates, query);
-
-            await OnBeforeSaveEntitiesAsync(entities);
-            await UnitOfWork.SaveChangesAsync();
-            await OnAfterSaveEntitiesAsync(entities);
-
+            await SaveChangesAsync(entities);
             return entities;
         }
 
         public virtual async Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query)
         {
             var entity = await Collection.UpdateByIdAsync(id, candidate, query);
-
-            await OnBeforeSaveEntitiesAsync(entity.Yield());
-            await UnitOfWork.SaveChangesAsync();
-            await OnAfterSaveEntitiesAsync(entity.Yield());
-
+            await SaveChangesAsync(entity.Yield());
             return entity;
         }
 
         public virtual async Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, ICandidate<TEntity, TKey>> candidatesByIds, Query<TEntity> query)
         {
             var entities = await Collection.UpdateByIdsAsync(candidatesByIds, query);
-
-            await OnBeforeSaveEntitiesAsync(entities);
-            await UnitOfWork.SaveChangesAsync();
-            await OnAfterSaveEntitiesAsync(entities);
-
+            await SaveChangesAsync(entities);
             return entities;
         }
 
         public async Task DeleteByIdAsync(TKey id)
         {
             await Collection.DeleteByIdAsync(id);
-
-            await OnBeforeSaveEntitiesAsync(Enumerable.Empty<TEntity>());
-            await UnitOfWork.SaveChangesAsync();
-            await OnAfterSaveEntitiesAsync(Enumerable.Empty<TEntity>());
+            await SaveChangesAsync(Enumerable.Empty<TEntity>());
         }
 
         public async Task DeleteByIdsAsync(IEnumerable<TKey> ids)
         {
             await Collection.DeleteByIdsAsync(ids);
+            await SaveChangesAsync(Enumerable.Empty<TEntity>());
+        }
 
-            await OnBeforeSaveEntitiesAsync(Enumerable.Empty<TEntity>());
-            await UnitOfWork.SaveChangesAsync();
-            await OnAfterSaveEntitiesAsync(Enumerable.Empty<TEntity>());
+        /// <summary>
+        /// Calls UnitOfWork.SaveChangesAsync() and pass modified items to OnBefore / OnAfter methods
+        /// </summary>
+        /// <param name="entities"></param>
+        /// <returns></returns>
+        protected virtual async Task SaveChangesAsync(IEnumerable<TEntity> entities)
+        {
+            await OnBeforeSaveEntitiesAsync(entities);
+            await _unitOfWork.SaveChangesAsync();
+            await OnAfterSaveEntitiesAsync(entities);
         }
 
         /// <summary>

--- a/Application/RDD.Application/Controllers/ReadOnlyAppController.cs
+++ b/Application/RDD.Application/Controllers/ReadOnlyAppController.cs
@@ -1,7 +1,9 @@
 ﻿using Rdd.Domain;
 using Rdd.Domain.Models.Querying;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Rdd.Domain.Helpers;
 
 namespace Rdd.Application.Controllers
 {
@@ -27,8 +29,23 @@ namespace Rdd.Application.Controllers
             Collection = collection;
         }
 
-        public virtual Task<ISelection<TEntity>> GetAsync(Query<TEntity> query) => Collection.GetAsync(query);
+        public virtual async Task<ISelection<TEntity>> GetAsync(Query<TEntity> query)
+        {
+            var entities = await Collection.GetAsync(query);
+            await OnAfterGetAsync(entities.Items);
+            return entities;
+        }
 
-        public virtual Task<TEntity> GetByIdAsync(TKey id, Query<TEntity> query) => Collection.GetByIdAsync(id, query);
+        public virtual async Task<TEntity> GetByIdAsync(TKey id, Query<TEntity> query)
+        {
+            var entity = await Collection.GetByIdAsync(id, query);
+            await OnAfterGetAsync(entity.Yield());
+            return entity;
+        }
+
+        /// <summary>
+        /// Called after all Get methods, should be used to apply custom modifications before items are returned via API 
+        /// </summary>
+        protected virtual Task OnAfterGetAsync(IEnumerable<TEntity> entities) => Task.CompletedTask;
     }
 }

--- a/Application/RDD.Application/Controllers/ReadOnlyAppController.cs
+++ b/Application/RDD.Application/Controllers/ReadOnlyAppController.cs
@@ -29,23 +29,10 @@ namespace Rdd.Application.Controllers
             Collection = collection;
         }
 
-        public virtual async Task<ISelection<TEntity>> GetAsync(Query<TEntity> query)
-        {
-            var entities = await Collection.GetAsync(query);
-            await OnAfterGetAsync(entities.Items);
-            return entities;
-        }
+        public virtual Task<ISelection<TEntity>> GetAsync(Query<TEntity> query) => Collection.GetAsync(query);
 
-        public virtual async Task<TEntity> GetByIdAsync(TKey id, Query<TEntity> query)
-        {
-            var entity = await Collection.GetByIdAsync(id, query);
-            await OnAfterGetAsync(entity.Yield());
-            return entity;
-        }
+        public virtual Task<TEntity> GetByIdAsync(TKey id, Query<TEntity> query) => Collection.GetByIdAsync(id, query);
 
-        /// <summary>
-        /// Called after all Get methods, should be used to apply custom modifications before items are returned via API 
-        /// </summary>
-        protected virtual Task OnAfterGetAsync(IEnumerable<TEntity> entities) => Task.CompletedTask;
+
     }
 }

--- a/Domain/Rdd.Domain/Helpers/IEnumerableExtensions.cs
+++ b/Domain/Rdd.Domain/Helpers/IEnumerableExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace Rdd.Domain.Helpers
+{
+    public static class IEnumerableExtensions
+    {
+        /// <summary>
+        /// Returns a generic IEnumerable for a single item, avoiding useless List or Array allocation
+        /// </summary>
+        public static IEnumerable<T> Yield<T>(this T item)
+        {
+            yield return item;
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
  - **Modification**: ``IExpressionTree.Children`` type changed ``IEnumerable<IExpressionTree>``-> ``IReadOnlyCollection<IExpressionTree>``
  - **Modification**: ``IReflectionProvider``-> ``IReflectionHelper``
  - **Modification**: Patchers now use ``IReflectionHelper``, are public and registered for performances boost.
+ - **Modification**: AppController now exposes ``SaveChangesAsync(IEnumerable<TEntity> entities)`` to save pending changes. The ``entities`` must be feeded with modified entities
  - **Removed**: unused classes `ExpressionHelper` and `NameValueCollectionHelper`
  - **Removed**: `IClonable<>` interface & ``Clone()`` method
  - **Removed**: `IEntityBase<TEntity, TKey>`, `EntityBase<TEntity, TKey>` and usages. This can be directly replaced by `IEntityBase<TKey>` or `EntityBase<TKey>`.
@@ -62,6 +63,7 @@
 ## New features
  - **Added**: CHANGELOG.md
  - **Added**: `IReflectionHelper.IsPseudoValue(Type type)` for types serialized and deserialized as JSON value.
+ - **Added**: new OnBeforeSaveEntitiesAsync and OnAfterSaveEntitiesAsync methods on AppController
  - **Added**: Opt-in support of Swagger for RDD controllers. Use `[ApiExplorerSettings(IgnoreApi = false)]` on your actions/controllers to display them.
  - **Added**: Inheritance support. To expose an API from a base class, use `RDDServiceCollectionExtensions.AddRddInheritanceConfiguration`. Then, Rdd will automatically take care of th rest for this API to work as expected. The interface `IInheritanceConfiguration` allows for the description of the diffetents classes to Rdd.
  - **Added**: `FieldsParser` exposes methods `ParseAllProperties` and `ParseFields` that can be used as generic or with type as argument.


### PR DESCRIPTION
## Problématique : 

Sur la couche AppController, on veut pouvoir effectuer des traitement avant la sauvegarde, et avant de retourner des éléments à l'API (donc après les Get / GetById, et après la sauvegarde). Actuellement, il est possible d'override totalement les méthodes existantes, de recopier le code de Rdd, et de se brancher sur là où l'on le souhaite.

Cependant, demander aux dev de recopier le code de Rdd pour ce faire est dangereux : en cas d’évolution de Rdd, jamais les devs iront penser à recopier les modifications... D'autre part, ce genre de modification est fastidieuse.

## Proposition : 

Nous offrons dans Rdd la possibilité de facilement exécuter du code à ces étapes du traitement, de façon à ne pas avoir à overrider les méthodes en recopiant le code. Plutôt que d'avoir à overrider 6 méthodes en écriture et 2 méthodes en lecture, il est possible de simplement se brancher sur 3 overrides.

3 méthodes sont donc introduites : 
- `protected virtual Task OnBeforeSaveEntitiesAsync(IEnumerable<TEntity> entities)`
- `protected virtual Task OnAfterSaveEntitiesAsync(IEnumerable<TEntity> entities)`
- `protected virtual Task OnAfterGetAsync(IEnumerable<TEntity> entities)`

Elles permettent de traiter les entités de façon ensembliste (via `IEnumerable<TEntity>`) et simplifie considérablement le code nécessaire au dev côté application consommatrice.

Note : la méthode d'extension Yield() introduite permet d'éviter une allocation inutile d'un array ou d'une list.