### PR TITLE
REM : EntityBase.Url set

### DIFF
--- a/src/Rdd.Domain/Models/EntityBase.cs
+++ b/src/Rdd.Domain/Models/EntityBase.cs
@@ -1,17 +1,15 @@
 ﻿using System;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Rdd.Domain.Models
 {
-    public abstract class EntityBase<TKey> : IEntityBase<TKey>
+    public class EntityBase<TKey> : IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
-        public virtual TKey Id { get; set; }
-        public virtual string Name { get; set; }
+        public TKey Id { get; set; }
+        public string Name { get; set; }
 
-        [NotMapped]
-        public virtual string Url { get; set; }
+        public string Url { get; }
 
-        public virtual object GetId() => Id;
+        object IPrimaryKey.GetId() => Id;
     }
 }

--- a/src/Rdd.Domain/Patchers/ObjectPatcher.cs
+++ b/src/Rdd.Domain/Patchers/ObjectPatcher.cs
@@ -65,6 +65,11 @@ namespace Rdd.Domain.Patchers
                 throw new BadRequestException($"Property {key} does not exist on type {entityType.Name}");
             }
 
+            if (!properties[key].CanWrite)
+            {
+                throw new BadRequestException($"Property {key} cannot be written to.");
+            }
+
             PatchProperty(patchedObject, properties[key], element);
         }
 

--- a/test/Rdd.Domain.Tests/Models/User.cs
+++ b/test/Rdd.Domain.Tests/Models/User.cs
@@ -1,12 +1,15 @@
-﻿using Rdd.Domain.Models;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net.Mail;
 
 namespace Rdd.Domain.Tests.Models
 {
-    public class User : EntityBase<Guid>
+    public class User : IEntityBase<Guid>
     {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Url { get; set; }
+
         public MailAddress Mail { get; set; }
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }
@@ -25,5 +28,7 @@ namespace Rdd.Domain.Tests.Models
 
             return result;
         }
+
+        public object GetId() => Id;
     }
 }

--- a/test/Rdd.Domain.Tests/PatchersTests.cs
+++ b/test/Rdd.Domain.Tests/PatchersTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Rdd.Domain.Exceptions;
 using Rdd.Domain.Helpers.Reflection;
 using Rdd.Domain.Json;
+using Rdd.Domain.Models;
 using Rdd.Domain.Patchers;
 using Rdd.Domain.Tests.Models;
 using System;
@@ -53,6 +54,15 @@ namespace Rdd.Domain.Tests
             services.TryAddSingleton<ObjectPatcher>();
 
             ServiceProvider = services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void PatchWrongProperty()
+        {
+            var patcher = new ObjectPatcher(PatcherProvider, ReflectionHelper);
+            var json = new JsonParser().Parse(@"{ ""url"": ""http://www.example.org"" }");
+
+            Assert.Throws<BadRequestException>(() => patcher.Patch(new EntityBase<int>(), json));
         }
 
         [Fact]

--- a/test/Rdd.Web.Tests/ExchangeRateIntegrationTest.cs
+++ b/test/Rdd.Web.Tests/ExchangeRateIntegrationTest.cs
@@ -37,7 +37,7 @@ namespace Rdd.Web.Tests
         [Fact]
         public async Task PutOkAsync()
         {
-            var serialized = JsonConvert.SerializeObject(new ExchangeRate { Id = 3, Name = "putted" });
+            var serialized = JsonConvert.SerializeObject(new { Id = 3, Name = "putted" });
             var content = new StringContent(serialized, Encoding.UTF8, "application/json");
 
             ExchangeRateController.ConfigurableAllowedHttpVerbs = Domain.Helpers.HttpVerbs.Put;
@@ -52,7 +52,7 @@ namespace Rdd.Web.Tests
         [Fact]
         public async Task PostOkAsync()
         {
-            var serialized = JsonConvert.SerializeObject(new ExchangeRate { Name = "posted" });
+            var serialized = JsonConvert.SerializeObject(new { Name = "posted" });
             var content = new StringContent(serialized, Encoding.UTF8, "application/json");
 
             ExchangeRateController.ConfigurableAllowedHttpVerbs = Domain.Helpers.HttpVerbs.Post;
@@ -97,7 +97,7 @@ namespace Rdd.Web.Tests
         [Fact]
         public async Task PutByIdOkAsync()
         {
-            var serialized = JsonConvert.SerializeObject(new ExchangeRate { Id = 5, Name = "putted2" });
+            var serialized = JsonConvert.SerializeObject(new  { Id = 5, Name = "putted2" });
             var content = new StringContent(serialized, Encoding.UTF8, "application/json");
 
             ExchangeRateController.ConfigurableAllowedHttpVerbs = Domain.Helpers.HttpVerbs.Put;

--- a/test/Rdd.Web.Tests/Serialization/PropertySerializerTests.cs
+++ b/test/Rdd.Web.Tests/Serialization/PropertySerializerTests.cs
@@ -106,8 +106,7 @@ namespace Rdd.Web.Tests.Serialization
                 Department = new Department
                 {
                     Id = 2,
-                    Name = "Foo",
-                    Url = "/api/departements/2"
+                    Name = "Foo"
                 }
             };
             var fields = ExpressionTree<User>.New(u => u.Department);

--- a/test/Rdd.Web.Tests/Serialization/UrlProviderTests.cs
+++ b/test/Rdd.Web.Tests/Serialization/UrlProviderTests.cs
@@ -57,7 +57,10 @@ namespace Rdd.Web.Tests.Serialization
 
         private class UserTest : User
         {
-            public override int Id { get => 10; }
+            public UserTest()
+            {
+                Id = 10;
+            }
         }
 
         private class UserTestUrlProvider : UrlProvider


### PR DESCRIPTION
En intégrant la dernière preview rdd, je me suis rendu compte qu'on pouvait encore brosser Entitybase:
 - je vire le abstract, car plus rien n'est abstract dans cette classe (en accord avec sonar)
 - je vire les virtual, qui n'ont plus lieu d'être (si l'on veut overrider un membre, on part plutôt de IentityBase
 - je vire le set de Url, ce qui permet de virer le NotMapped, car EF n'ira pas embêter ce membre
 - j'implémente GetId explicitement

Ce faisant, je me suis rendu compte que le objectpatcher planté peu élégamment sur les propriétés sans set; donc je rajoute le test