### PR TITLE
add : rddbuilder.services en public

### DIFF
--- a/src/Rdd.Web/Helpers/RddBuilder.cs
+++ b/src/Rdd.Web/Helpers/RddBuilder.cs
@@ -15,7 +15,7 @@ namespace Rdd.Web.Helpers
             JsonConverters = new List<JsonConverter>();
         }
 
-        internal IServiceCollection Services { get; }
+        public IServiceCollection Services { get; }
 
         internal List<JsonConverter> JsonConverters { get; }
     }


### PR DESCRIPTION
c con, mais ça permet le chainage dans l'enregistrement des dépendances, ce qui est assez courant