### PR TITLE
MOD : default paging on get only

### DIFF
--- a/src/Rdd.Web/Querying/QueryParser.cs
+++ b/src/Rdd.Web/Querying/QueryParser.cs
@@ -69,12 +69,21 @@ namespace Rdd.Web.Querying
             else if (query.Fields.Contains((ISelection c) => c.Count))
             {
                 query.Options.NeedCount = true;
-                query.Options.NeedEnumeration = query.Fields.Children.Count() != 1;
+                query.Options.NeedEnumeration = query.Fields.Children.Count != 1;
             }
 
-            if (query.Page == Page.Unlimited)
+            switch (verb)
             {
-                query.Page = _rddOptions.Value.DefaultPage;
+                case HttpVerbs.Get:
+                    if (query.Page == Page.Unlimited)
+                    {
+                        query.Page = _rddOptions.Value.DefaultPage;
+                    }
+                    break;
+
+                default:
+                    query.Page = Page.Unlimited;
+                    break;
             }
 
             query.Filter = _webFilterConverter.ToExpression(filters);

--- a/src/Rdd.Web/Querying/WebPageParser.cs
+++ b/src/Rdd.Web/Querying/WebPageParser.cs
@@ -22,7 +22,7 @@ namespace Rdd.Web.Querying
                 throw new BadRequestException(nameof(input));
             }
 
-            if (input == "1") //...&paging=1 <=> &paging=0,100
+            if (input == "1") //...&paging=1 <=> &paging=0,10
             {
                 return _rddOptions.Value.DefaultPage;
             }

--- a/test/Rdd.Web.Tests/QueryParserTests.cs
+++ b/test/Rdd.Web.Tests/QueryParserTests.cs
@@ -95,6 +95,21 @@ namespace Rdd.Web.Tests
         }
 
         [Theory]
+        [InlineData(HttpVerbs.Get, 0, 10)]
+        [InlineData(HttpVerbs.Post, 0, 0)]
+        [InlineData(HttpVerbs.Put, 0, 0)]
+        [InlineData(HttpVerbs.Delete, 0, 0)]
+        public void DefaultPaging(HttpVerbs verb, int offset, int limit)
+        {
+            var dico = new Dictionary<string, StringValues>();
+            var query = QueryParserHelper.GetQueryParser<User>().Parse(verb, dico, true);
+
+            Assert.Equal(offset, query.Page.Offset);
+            Assert.Equal(limit, query.Page.Limit);
+        }
+
+        [Theory]
+        [InlineData("1", 0, 10)]
         [InlineData("0,10", 0, 10)]
         [InlineData("-0,10", 0, 10)]
         [InlineData("10,20", 10, 20)]


### PR DESCRIPTION
FIX : problèmes de paging sur put multiples

Cette PR propose d'arrêter le paging par défaut en dehors des requêtes de type GET. Cela nous a créé de nombreux problèmes, encore sur la dernière rc de poplee talent sur du put multiples. Mais surtout, je pense que l'implémentation actuelle ne correspond pas à l'intention, qui était d'empêcher les requêtes en GET sur toute la base