### PR TITLE
ADD : utility methods on RddBuilder

### DIFF
--- a/src/Rdd.Web/Helpers/RddBuilderExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddBuilderExtensions.cs
@@ -1,0 +1,140 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Newtonsoft.Json;
+using Rdd.Application;
+using Rdd.Domain;
+using Rdd.Domain.Models;
+using Rdd.Domain.Patchers;
+using Rdd.Domain.Rights;
+using Rdd.Web.Models;
+using System;
+
+namespace Rdd.Web.Helpers
+{
+    public static class RddBuilderExtensions
+    {
+        private static RddBuilder AddJsonConverter(this RddBuilder rddBuilder, JsonConverter jsonConverter)
+        {
+            rddBuilder.JsonConverters.Add(jsonConverter);
+            return rddBuilder;
+        }
+
+        public static RddBuilder AddInheritanceConfiguration<TConfig, TEntity, TKey>(this RddBuilder rddBuilder, TConfig config)
+            where TConfig : class, IInheritanceConfiguration<TEntity>
+            where TEntity : class, IEntityBase<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            var services = rddBuilder.Services;
+
+            services.AddSingleton<IInheritanceConfiguration>(s => config);
+            services.AddSingleton<IInheritanceConfiguration<TEntity>>(s => config);
+
+            services.TryAddSingleton<IPatcher<TEntity>, BaseClassPatcher<TEntity>>();
+            services.TryAddSingleton<IInstanciator<TEntity>, BaseClassInstanciator<TEntity>>();
+
+            rddBuilder.AddJsonConverter(new BaseClassJsonConverter<TEntity>(config));
+
+            return rddBuilder;
+        }
+
+        public static RddBuilder AddReadOnlyRepository<TRepository, TEntity>(this RddBuilder rddBuilder)
+            where TRepository : class, IReadOnlyRepository<TEntity>
+            where TEntity : class
+        {
+            rddBuilder.Services
+                .AddScoped<IReadOnlyRepository<TEntity>, TRepository>(s => s.GetRequiredService<TRepository>())
+                .AddScoped<TRepository>();
+
+            return rddBuilder;
+        }
+
+        public static RddBuilder AddRepository<TRepository, TEntity>(this RddBuilder rddBuilder)
+            where TRepository : class, IRepository<TEntity>
+            where TEntity : class
+        {
+            rddBuilder.Services
+                .AddScoped<IRepository<TEntity>, TRepository>(s => s.GetRequiredService<TRepository>())
+                .AddScoped<IReadOnlyRepository<TEntity>, TRepository>(s => s.GetRequiredService<TRepository>())
+                .AddScoped<TRepository>();
+
+            return rddBuilder;
+        }
+
+        public static RddBuilder AddReadOnlyRestCollection<TCollection, TEntity, TKey>(this RddBuilder rddBuilder)
+            where TCollection : class, IReadOnlyRestCollection<TEntity, TKey>
+            where TEntity : class, IEntityBase<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            rddBuilder.Services
+                .AddScoped<IReadOnlyRestCollection<TEntity, TKey>, TCollection>(s => s.GetRequiredService<TCollection>())
+                .AddScoped<TCollection>();
+
+            return rddBuilder;
+        }
+
+        public static RddBuilder AddRestCollection<TCollection, TEntity, TKey>(this RddBuilder rddBuilder)
+            where TCollection : class, IRestCollection<TEntity, TKey>
+            where TEntity : class, IEntityBase<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            rddBuilder.Services
+                .AddScoped<IRestCollection<TEntity, TKey>, TCollection>(s => s.GetRequiredService<TCollection>())
+                .AddScoped<IReadOnlyRestCollection<TEntity, TKey>, TCollection>(s => s.GetRequiredService<TCollection>())
+                .AddScoped<TCollection>();
+
+            return rddBuilder;
+        }
+
+        public static RddBuilder AddReadOnlyAppController<TController, TEntity, TKey>(this RddBuilder rddBuilder)
+            where TController : class, IReadOnlyAppController<TEntity, TKey>
+            where TEntity : class, IEntityBase<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            rddBuilder.Services
+                .AddScoped<IReadOnlyAppController<TEntity, TKey>, TController>(s => s.GetRequiredService<TController>())
+                .AddScoped<TController>();
+
+            return rddBuilder;
+        }
+
+        public static RddBuilder AddAppController<TController, TEntity, TKey>(this RddBuilder rddBuilder)
+            where TController : class, IAppController<TEntity, TKey>
+            where TEntity : class, IEntityBase<TKey>
+            where TKey : IEquatable<TKey>
+        {
+            rddBuilder.Services
+                .AddScoped<IAppController<TEntity, TKey>, TController>(s => s.GetRequiredService<TController>())
+                .AddScoped<IReadOnlyAppController<TEntity, TKey>, TController>(s => s.GetRequiredService<TController>())
+                .AddScoped<TController>();
+
+            return rddBuilder;
+        }
+
+        public static RddBuilder AddPatcher<TPatcher, T>(this RddBuilder rddBuilder)
+            where TPatcher : class, IPatcher<T>
+            where T : class
+        {
+            rddBuilder.Services
+                .AddSingleton<IPatcher<T>, TPatcher>(s => s.GetRequiredService<TPatcher>())
+                .AddSingleton<TPatcher>();
+
+            return rddBuilder;
+        }
+
+        public static RddBuilder WithDefaultRights(this RddBuilder rddBuilder, RightDefaultMode mode)
+        {
+            switch (mode)
+            {
+                case RightDefaultMode.Closed:
+                    rddBuilder.Services.AddSingleton(typeof(IRightExpressionsHelper<>), typeof(ClosedRightExpressionsHelper<>));
+                    break;
+                case RightDefaultMode.Open:
+                    rddBuilder.Services.AddSingleton(typeof(IRightExpressionsHelper<>), typeof(OpenRightExpressionsHelper<>));
+                    break;
+                default:
+                    throw new ArgumentException("Invalid right mode", nameof(mode));
+            }
+            return rddBuilder;
+        }
+    }
+}

--- a/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -16,24 +17,21 @@ using Rdd.Domain.Patchers;
 using Rdd.Domain.Rights;
 using Rdd.Infra.Helpers;
 using Rdd.Infra.Storage;
-using Rdd.Web.Models;
 using Rdd.Web.Querying;
 using Rdd.Web.Serialization.Providers;
 using Rdd.Web.Serialization.Serializers;
 using Rdd.Web.Serialization.UrlProviders;
 using System;
 using System.Globalization;
-using Microsoft.AspNetCore.Mvc;
 
 namespace Rdd.Web.Helpers
 {
     public static class RddServiceCollectionExtensions
     {
-        private static RddBuilder AddRddCore<TDbContext>(this IServiceCollection services)
+        public static RddBuilder AddRdd<TDbContext>(this IServiceCollection services)
             where TDbContext : DbContext
         {
             services.AddOptions<RddOptions>();
-            services.TryAddScoped<DbContext>(p => p.GetRequiredService<TDbContext>());
 
             services.TryAddSingleton(typeof(IInstanciator<>), typeof(DefaultInstanciator<>));
             services.TryAddSingleton<IPatcherProvider, PatcherProvider>();
@@ -44,100 +42,7 @@ namespace Rdd.Web.Helpers
             services.TryAddSingleton<DynamicPatcher>();
             services.TryAddSingleton<ObjectPatcher>();
 
-            services.TryAddSingleton<IJsonParser, JsonParser>();
-            services.TryAddSingleton<ICandidateParser, CandidateParser>();
-            services.TryAddSingleton<IStringConverter, StringConverter>();
-            services.TryAddSingleton<IExpressionParser, ExpressionParser>();
-            services.TryAddSingleton(typeof(IWebFilterConverter<>), typeof(WebFilterConverter<>));
-            services.TryAddSingleton<IPagingParser, PagingParser>();
-            services.TryAddSingleton<IFilterParser, FilterParser>();
-            services.TryAddSingleton<IFieldsParser, FieldsParser>();
-            services.TryAddSingleton<IOrderByParser, OrderByParser>();
-            services.TryAddSingleton(typeof(IQueryParser<>), typeof(QueryParser<>));
-
-            services.TryAddScoped<IStorageService, EFStorageService>();
-            services.TryAddScoped<IUnitOfWork, UnitOfWork>();
-
-            services.TryAddScoped(typeof(IReadOnlyRepository<>), typeof(ReadOnlyRepository<>));
-            services.TryAddScoped(typeof(IRepository<>), typeof(Repository<>));
-            services.TryAddScoped(typeof(IReadOnlyRestCollection<,>), typeof(ReadOnlyRestCollection<,>));
-            services.TryAddScoped(typeof(IRestCollection<,>), typeof(RestCollection<,>));
-            services.TryAddScoped(typeof(IReadOnlyAppController<,>), typeof(ReadOnlyAppController<,>));
-            services.TryAddScoped(typeof(IAppController<,>), typeof(AppController<,>));
-
-            services.AddHttpContextAccessor();
-
-            // closed by default, overridable with AddRddDefaultRights
-            services.TryAddSingleton(typeof(IRightExpressionsHelper<>), typeof(ClosedRightExpressionsHelper<>));
-
-            return new RddBuilder(services)
-                .ApplyRddSetupOptions();
-        }
-
-        private static RddBuilder AddRddCore<TDbContext>(this IServiceCollection services, Action<RddOptions> onConfigure)
-            where TDbContext : DbContext
-        {
-            var builder = services.AddRddCore<TDbContext>();
-            services.Configure(onConfigure);
-            return builder;
-        }
-
-        public static RddBuilder AddJsonConverter(this RddBuilder rddBuilder, JsonConverter jsonConverter)
-        {
-            rddBuilder.JsonConverters.Add(jsonConverter);
-            return rddBuilder;
-        }
-
-        private static RddBuilder ApplyRddSetupOptions(this RddBuilder rddBuilder)
-        {
-            rddBuilder.Services.PostConfigure<MvcJsonOptions>(o =>
-            {
-                foreach (JsonConverter converter in rddBuilder.JsonConverters)
-                {
-                    o.SerializerSettings.Converters.Add(converter);
-                }
-            });
-            return rddBuilder;
-        }
-
-        public static RddBuilder AddRddInheritanceConfiguration<TConfig, TEntity, TKey>(this RddBuilder rddBuilder, TConfig config)
-            where TConfig : class, IInheritanceConfiguration<TEntity>
-            where TEntity : class, IEntityBase<TKey>
-            where TKey : IEquatable<TKey>
-        {
-            var services = rddBuilder.Services;
-
-            services.AddSingleton<IInheritanceConfiguration>(s => config);
-            services.AddSingleton<IInheritanceConfiguration<TEntity>>(s => config);
-
-            services.TryAddSingleton<IPatcher<TEntity>, BaseClassPatcher<TEntity>>();
-            services.TryAddSingleton<IInstanciator<TEntity>, BaseClassInstanciator<TEntity>>();
-
-            rddBuilder.AddJsonConverter(new BaseClassJsonConverter<TEntity>(config));
-
-            return rddBuilder;
-        }
-
-        public static RddBuilder WithDefaultRights(this RddBuilder rddBuilder, RightDefaultMode mode)
-        {
-            switch (mode)
-            {
-                case RightDefaultMode.Closed:
-                    rddBuilder.Services.AddSingleton(typeof(IRightExpressionsHelper<>), typeof(ClosedRightExpressionsHelper<>));
-                    break;
-                case RightDefaultMode.Open:
-                    rddBuilder.Services.AddSingleton(typeof(IRightExpressionsHelper<>), typeof(OpenRightExpressionsHelper<>));
-                    break;
-                default:
-                    throw new ArgumentException("Invalid right mode", nameof(mode));
-            }
-            return rddBuilder;
-        }
-
-        public static RddBuilder AddRddSerialization(this RddBuilder rddBuilder)
-        {
-            var services = rddBuilder.Services;
-
+            //serialization
             services.AddHttpContextAccessor();
             services.TryAddSingleton<IUrlProvider, UrlProvider>();
 
@@ -156,23 +61,53 @@ namespace Rdd.Web.Helpers
             services.TryAddSingleton<ToStringSerializer>();
             services.TryAddSingleton<ValueSerializer>();
 
-            return rddBuilder;
-        }
+            services.TryAddSingleton<IJsonParser, JsonParser>();
+            services.TryAddSingleton<ICandidateParser, CandidateParser>();
+            services.TryAddSingleton<IStringConverter, StringConverter>();
+            services.TryAddSingleton<IExpressionParser, ExpressionParser>();
+            services.TryAddSingleton(typeof(IWebFilterConverter<>), typeof(WebFilterConverter<>));
+            services.TryAddSingleton<IPagingParser, PagingParser>();
+            services.TryAddSingleton<IFilterParser, FilterParser>();
+            services.TryAddSingleton<IFieldsParser, FieldsParser>();
+            services.TryAddSingleton<IOrderByParser, OrderByParser>();
+            services.TryAddSingleton(typeof(IQueryParser<>), typeof(QueryParser<>));
 
-        public static RddBuilder AddRdd<TDbContext>(this IServiceCollection services)
-            where TDbContext : DbContext
-        {
-            return services
-                .AddRddCore<TDbContext>()
-                .AddRddSerialization();
+            //scoped services
+            services.TryAddScoped<DbContext>(p => p.GetRequiredService<TDbContext>());
+            services.TryAddScoped<IStorageService, EFStorageService>();
+            services.TryAddScoped<IUnitOfWork, UnitOfWork>();
+
+            services.TryAddScoped(typeof(IReadOnlyRepository<>), typeof(ReadOnlyRepository<>));
+            services.TryAddScoped(typeof(IRepository<>), typeof(Repository<>));
+            services.TryAddScoped(typeof(IReadOnlyRestCollection<,>), typeof(ReadOnlyRestCollection<,>));
+            services.TryAddScoped(typeof(IRestCollection<,>), typeof(RestCollection<,>));
+            services.TryAddScoped(typeof(IReadOnlyAppController<,>), typeof(ReadOnlyAppController<,>));
+            services.TryAddScoped(typeof(IAppController<,>), typeof(AppController<,>));
+            
+            // closed by default, overridable with AddRddDefaultRights
+            services.TryAddSingleton(typeof(IRightExpressionsHelper<>), typeof(ClosedRightExpressionsHelper<>));
+
+            return new RddBuilder(services).ApplyRddSetupOptions();
         }
 
         public static RddBuilder AddRdd<TDbContext>(this IServiceCollection services, Action<RddOptions> onConfigure)
             where TDbContext : DbContext
         {
-            return services
-                .AddRddCore<TDbContext>(onConfigure)
-                .AddRddSerialization();
+            var builder = services.AddRdd<TDbContext>();
+            services.Configure(onConfigure);
+            return builder;
+        }
+
+        private static RddBuilder ApplyRddSetupOptions(this RddBuilder rddBuilder)
+        {
+            rddBuilder.Services.PostConfigure<MvcJsonOptions>(o =>
+            {
+                foreach (JsonConverter converter in rddBuilder.JsonConverters)
+                {
+                    o.SerializerSettings.Converters.Add(converter);
+                }
+            });
+            return rddBuilder;
         }
 
         /// <summary>

--- a/test/Rdd.Web.Tests/Services/RddBuilderTests.cs
+++ b/test/Rdd.Web.Tests/Services/RddBuilderTests.cs
@@ -1,0 +1,265 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Rdd.Application;
+using Rdd.Application.Controllers;
+using Rdd.Domain;
+using Rdd.Domain.Helpers.Expressions;
+using Rdd.Domain.Helpers.Reflection;
+using Rdd.Domain.Json;
+using Rdd.Domain.Models;
+using Rdd.Domain.Models.Querying;
+using Rdd.Domain.Patchers;
+using Rdd.Domain.Rights;
+using Rdd.Domain.Tests.Models;
+using Rdd.Infra.Storage;
+using Rdd.Web.Helpers;
+using Rdd.Web.Querying;
+using Rdd.Web.Serialization.Providers;
+using Rdd.Web.Tests.ServerMock;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Rdd.Web.Tests.Services
+{
+    public class RddBuilderTests
+    {
+        public abstract class Hierarchy2 : IEntityBase<int>
+        {
+            public string Name { get; set; }
+            public string Url { get; set; }
+            public string Type { get; set; }
+            public int Id { get; set; }
+
+            public Hierarchy2 Clone() => this;
+            public object GetId() => Id;
+            public void SetId(object id) => Id = (int)id;
+        }
+
+        public class Super : Hierarchy2
+        {
+        }
+
+        public class InheritanceConfiguration2 : IInheritanceConfiguration<Hierarchy2>
+        {
+            public Type BaseType => typeof(Hierarchy2);
+
+            public string Discriminator => "type";
+
+            public IReadOnlyDictionary<string, Type> Mappings => new Dictionary<string, Type>
+            {
+                { "super", typeof(Super) }
+            };
+        }
+
+        [Fact]
+        public void TestInheritanceRegister()
+        {
+            var services = new ServiceCollection();
+            services.TryAddSingleton<IPatcherProvider, PatcherProvider>();
+            services.TryAddSingleton<IReflectionHelper, ReflectionHelper>();
+
+            new RddBuilder(services)
+                .AddInheritanceConfiguration<InheritanceConfiguration, Hierarchy, int>(new InheritanceConfiguration())
+                .AddInheritanceConfiguration<InheritanceConfiguration2, Hierarchy2, int>(new InheritanceConfiguration2());
+
+            var provider = services.BuildServiceProvider();
+
+            var configs = provider.GetRequiredService<IEnumerable<IInheritanceConfiguration>>();
+
+            Assert.Equal(2, configs.ToList().Count);
+
+            provider.GetRequiredService<IInheritanceConfiguration<Hierarchy>>();
+            provider.GetRequiredService<IInheritanceConfiguration<Hierarchy2>>();
+
+            Assert.IsType<BaseClassPatcher<Hierarchy>>(provider.GetRequiredService<IPatcher<Hierarchy>>());
+            Assert.IsType<BaseClassInstanciator<Hierarchy>>(provider.GetRequiredService<IInstanciator<Hierarchy>>());
+        }
+
+        [Fact]
+        public void TestEmptyInheritanceRegister()
+        {
+            var configs = new ServiceCollection().BuildServiceProvider().GetRequiredService<IEnumerable<IInheritanceConfiguration>>();
+
+            Assert.Empty(configs);
+        }
+
+        class RepoPipo : IRepository<Hierarchy>
+        {
+            public void Add(Hierarchy entity) => throw new NotImplementedException();
+            public void AddRange(IEnumerable<Hierarchy> entities) => throw new NotImplementedException();
+            public Task<int> CountAsync(Query<Hierarchy> query) => throw new NotImplementedException();
+            public void DiscardChanges(Hierarchy entity) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> GetAsync(Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> PrepareAsync(IEnumerable<Hierarchy> entities, Query<Hierarchy> query) => throw new NotImplementedException();
+            public void Remove(Hierarchy entity) => throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void TestReadOnlyRepoRegister()
+        {
+            var services = new ServiceCollection();
+            new RddBuilder(services).AddReadOnlyRepository<RepoPipo, Hierarchy>();
+            var provider = services.BuildServiceProvider();
+
+            Assert.Null(provider.GetService<IRepository<Hierarchy>>());
+
+            var repo2 = provider.GetRequiredService<IReadOnlyRepository<Hierarchy>>();
+            var repo3 = provider.GetRequiredService<RepoPipo>();
+
+            Assert.Equal(repo2, repo3);
+        }
+
+        [Fact]
+        public void TestRepoRegister()
+        {
+            var services = new ServiceCollection();
+            new RddBuilder(services).AddRepository<RepoPipo, Hierarchy>();
+            var provider = services.BuildServiceProvider();
+
+            var repo = provider.GetRequiredService<IRepository<Hierarchy>>();
+            var repo2 = provider.GetRequiredService<IReadOnlyRepository<Hierarchy>>();
+            var repo3 = provider.GetRequiredService<RepoPipo>();
+
+            Assert.Equal(repo, repo2);
+            Assert.Equal(repo, repo3);
+            Assert.Equal(repo2, repo3);
+        }
+
+        class CollectionPipo : IRestCollection<Hierarchy, int>
+        {
+            public Task<bool> AnyAsync(Query<Hierarchy> query) => throw new NotImplementedException();
+
+            public Task<Hierarchy> CreateAsync(ICandidate<Hierarchy, int> candidate, Query<Hierarchy> query = null) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> CreateAsync(IEnumerable<ICandidate<Hierarchy, int>> candidates, Query<Hierarchy> query = null) => throw new NotImplementedException();
+
+            public Task DeleteByIdAsync(int id) => throw new NotImplementedException();
+            public Task DeleteByIdsAsync(IEnumerable<int> ids) => throw new NotImplementedException();
+
+            public Task<ISelection<Hierarchy>> GetAsync(Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task<Hierarchy> GetByIdAsync(int id, Query<Hierarchy> query) => throw new NotImplementedException();
+
+            public Task<Hierarchy> UpdateByIdAsync(int id, ICandidate<Hierarchy, int> candidate, Query<Hierarchy> query = null) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> UpdateByIdsAsync(IDictionary<int, ICandidate<Hierarchy, int>> candidatesByIds, Query<Hierarchy> query = null) => throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void TestReadOnlyCollectionRegister()
+        {
+            var services = new ServiceCollection();
+            new RddBuilder(services).AddReadOnlyRestCollection<CollectionPipo, Hierarchy, int>();
+            var provider = services.BuildServiceProvider();
+
+            Assert.Null(provider.GetService<IRestCollection<Hierarchy, int>>());
+
+            var collection2 = provider.GetRequiredService<IReadOnlyRestCollection<Hierarchy, int>>();
+            var collection3 = provider.GetRequiredService<CollectionPipo>();
+
+            Assert.Equal(collection3, collection2);
+        }
+
+        [Fact]
+        public void TestCollectionRegister()
+        {
+            var services = new ServiceCollection();
+            new RddBuilder(services).AddRestCollection<CollectionPipo, Hierarchy, int>();
+            var provider = services.BuildServiceProvider();
+
+            var collection = provider.GetRequiredService<IRestCollection<Hierarchy, int>>();
+            var collection2 = provider.GetRequiredService<IReadOnlyRestCollection<Hierarchy, int>>();
+            var collection3 = provider.GetRequiredService<CollectionPipo>();
+
+            Assert.Equal(collection, collection2);
+            Assert.Equal(collection, collection3);
+            Assert.Equal(collection3, collection2);
+        }
+
+        class ControllerPipo : IAppController<Hierarchy, int>
+        {
+            public Task<Hierarchy> CreateAsync(ICandidate<Hierarchy, int> candidate, Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> CreateAsync(IEnumerable<ICandidate<Hierarchy, int>> candidates, Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task DeleteByIdAsync(int id) => throw new NotImplementedException();
+            public Task DeleteByIdsAsync(IEnumerable<int> ids) => throw new NotImplementedException();
+            public Task<ISelection<Hierarchy>> GetAsync(Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task<Hierarchy> GetByIdAsync(int id, Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task<Hierarchy> UpdateByIdAsync(int id, ICandidate<Hierarchy, int> candidate, Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> UpdateByIdsAsync(IDictionary<int, ICandidate<Hierarchy, int>> candidatesByIds, Query<Hierarchy> query) => throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void TestReadOnlyControllerRegister()
+        {
+            var services = new ServiceCollection();
+            new RddBuilder(services).AddReadOnlyAppController<ControllerPipo, Hierarchy, int>();
+            var provider = services.BuildServiceProvider();
+
+            Assert.Null(provider.GetService<IAppController<Hierarchy, int>>());
+
+            var controller2 = provider.GetRequiredService<IReadOnlyAppController<Hierarchy, int>>();
+            var controller3 = provider.GetRequiredService<ControllerPipo>();
+
+            Assert.Equal(controller3, controller2);
+        }
+
+        [Fact]
+        public void TestControllerRegister()
+        {
+            var services = new ServiceCollection();
+            new RddBuilder(services).AddAppController<ControllerPipo, Hierarchy, int>();
+            var provider = services.BuildServiceProvider();
+
+            var controller = provider.GetRequiredService<IAppController<Hierarchy, int>>();
+            var controller2 = provider.GetRequiredService<IReadOnlyAppController<Hierarchy, int>>();
+            var controller3 = provider.GetRequiredService<ControllerPipo>();
+
+            Assert.Equal(controller, controller2);
+            Assert.Equal(controller, controller3);
+            Assert.Equal(controller3, controller2);
+        }
+
+        class PatcherPipo : IPatcher<RandomClass>
+        {
+            public object InitialValue(PropertyInfo property, object patchedObject) => throw new NotImplementedException();
+            public RandomClass Patch(RandomClass patchedObject, JsonObject json) => throw new NotImplementedException();
+            public object PatchValue(object patchedObject, Type expectedType, IJsonElement json) => throw new NotImplementedException();
+        }
+
+        class RandomClass { }
+
+        [Fact]
+        public void TestPatcherRegister()
+        {
+            var services = new ServiceCollection();
+            services.TryAddSingleton<IPatcherProvider, PatcherProvider>();
+            services.TryAddSingleton<IReflectionHelper, ReflectionHelper>();
+            new RddBuilder(services).AddPatcher<PatcherPipo, RandomClass>();
+            var provider = services.BuildServiceProvider();
+
+            var patcher = provider.GetRequiredService<IPatcher<RandomClass>>();
+            var patcher2 = provider.GetRequiredService<PatcherPipo>();
+
+            Assert.Equal(patcher, patcher2);
+
+            var patcherProvider = provider.GetRequiredService<IPatcherProvider>();
+            var patcher3 = patcherProvider.GetPatcher(typeof(RandomClass), null);
+
+            Assert.Equal(patcher3, patcher2);
+            Assert.Equal(patcher3, patcher);
+        }
+
+        [Theory]
+        [InlineData(RightDefaultMode.Open, typeof(OpenRightExpressionsHelper<Hierarchy>))]
+        [InlineData(RightDefaultMode.Closed, typeof(ClosedRightExpressionsHelper<Hierarchy>))]
+        public void TestRights(RightDefaultMode mode, Type expectedType)
+        {
+            var services = new ServiceCollection();
+            new RddBuilder(services).WithDefaultRights(mode);
+            var provider = services.BuildServiceProvider();
+
+            Assert.IsType(expectedType, provider.GetRequiredService<IRightExpressionsHelper<Hierarchy>>());
+        }
+    }
+}

--- a/test/Rdd.Web.Tests/Services/ServicesCollectionTests.cs
+++ b/test/Rdd.Web.Tests/Services/ServicesCollectionTests.cs
@@ -16,82 +16,13 @@ using Rdd.Web.Tests.ServerMock;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Rdd.Web.Tests.Services
 {
     public class ServicesCollectionTests
     {
-        public abstract class Hierarchy2 : IEntityBase<int>
-        {
-            public string Name { get; set; }
-            public string Url { get; set; }
-            public string Type { get; set; }
-            public int Id { get; set; }
-
-            public Hierarchy2 Clone() => this;
-            public object GetId() => Id;
-            public void SetId(object id) => Id = (int)id;
-        }
-
-        public class Super : Hierarchy2
-        {
-        }
-
-        public class InheritanceConfiguration2 : IInheritanceConfiguration<Hierarchy2>
-        {
-            public Type BaseType => typeof(Hierarchy2);
-
-            public string Discriminator => "type";
-
-            public IReadOnlyDictionary<string, Type> Mappings => new Dictionary<string, Type>
-            {
-                { "super", typeof(Super) }
-            };
-        }
-
-        [Fact]
-        public void TestInheritanceRegister()
-        {
-            var services = new ServiceCollection();
-            var setup = new RddBuilder(services);
-
-            setup.AddRddInheritanceConfiguration<InheritanceConfiguration, Hierarchy, int>(new InheritanceConfiguration());
-            setup.AddRddInheritanceConfiguration<InheritanceConfiguration2, Hierarchy2, int>(new InheritanceConfiguration2());
-
-            var provider = services.BuildServiceProvider();
-
-            var configs = provider.GetRequiredService<IEnumerable<IInheritanceConfiguration>>();
-
-            Assert.Equal(2, configs.ToList().Count);
-
-            provider.GetRequiredService<IInheritanceConfiguration<Hierarchy>>();
-            provider.GetRequiredService<IInheritanceConfiguration<Hierarchy2>>();
-        }
-
-        [Fact]
-        public void TestEmptyInheritanceRegister()
-        {
-            var services = new ServiceCollection();
-            var provider = services.BuildServiceProvider();
-
-            var configs = provider.GetRequiredService<IEnumerable<IInheritanceConfiguration>>();
-
-            Assert.Empty(configs);
-        }
-
-        [Fact]
-        public void TestRddSerializationRegister()
-        {
-            var services = new ServiceCollection();
-            var setup = new RddBuilder(services);
-            setup.AddRddSerialization();
-
-            var provider = services.BuildServiceProvider();
-
-            Assert.NotNull(provider.GetRequiredService<ISerializerProvider>());
-        }
-
         [Fact]
         public void TestRddRegister()
         {
@@ -100,7 +31,6 @@ namespace Rdd.Web.Tests.Services
             services.AddDbContext<ExchangeRateDbContext>();//necessary or .AddRdd fails
             services.AddRdd<ExchangeRateDbContext>();
 
-            services.AddScoped(typeof(IRightExpressionsHelper<>),typeof(OpenRightExpressionsHelper<>));
             var provider = services.BuildServiceProvider();
 
             Assert.NotNull(provider.GetRequiredService<IUnitOfWork>());
@@ -110,6 +40,8 @@ namespace Rdd.Web.Tests.Services
             Assert.NotNull(provider.GetRequiredService<IStringConverter>());
             Assert.NotNull(provider.GetRequiredService<IExpressionParser>());
             Assert.NotNull(provider.GetRequiredService<ICandidateParser>());
+
+            Assert.NotNull(provider.GetRequiredService<ISerializerProvider>());
 
             Assert.NotNull(provider.GetRequiredService<IReadOnlyRepository<ExchangeRate>>());
             Assert.NotNull(provider.GetRequiredService<IRepository<ExchangeRate>>());


### PR DESCRIPTION
Cette PR espère simplifier l'enregistrement de ses repos/collections custom via la création de deux méthodes dédiées sur le RddBuilder:
 - AddReadOnlyRepository
 - AddRepository
 - AddReadOnlyRestCollection
 - AddRestCollection
 - AddReadOnlyAppController
 - AddAppController
 - AddPatcher

Se faisant, ces méthodes permettent de:
 - ne pas se tromper de scope
 - offrir une interface plus sympa à lire/expressif que le natif
 - ne pas oublier son repo en readonly et en direct
 - garantir que tout ces repos sont les mêmes (au scope scoped)

Rien que chez poplee talent, j'ai déjà repéré que cela n'était pas systématiquement/correctement fait, d'où cette PR.

N'hésitez pas à me dire si je me suis planté sur la manière d'enregistrer les dépendances, j'ai beaucoup hésité avec TryAdd notamment, 