### PR TITLE
Before/After save changes cleanup + better UnitOfWork

### DIFF
--- a/src/Rdd.Application/IUnitOfWork.cs
+++ b/src/Rdd.Application/IUnitOfWork.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Rdd.Application
 {
-    public interface IUnitOfWork : IDisposable
+    public interface IUnitOfWork
     {
         Task SaveChangesAsync();
     }

--- a/src/Rdd.Infra/Storage/EventProcessableUnitOfWork.cs
+++ b/src/Rdd.Infra/Storage/EventProcessableUnitOfWork.cs
@@ -9,12 +9,12 @@ using Rdd.Infra.Exceptions;
 
 namespace Rdd.Infra.Storage
 {
-    public class HookedUnitOfWork : IUnitOfWork
+    public class EventProcessableUnitOfWork : IUnitOfWork
     {
         private readonly DbContext _dbContext;
         private readonly List<ISaveEventProcessor> _saveEventProcessors;
 
-        public HookedUnitOfWork(DbContext dbContext, IEnumerable<ISaveEventProcessor> saveEventProcessors)
+        public EventProcessableUnitOfWork(DbContext dbContext, IEnumerable<ISaveEventProcessor> saveEventProcessors)
         {
             _dbContext = dbContext;
             _saveEventProcessors = (saveEventProcessors ?? Enumerable.Empty<ISaveEventProcessor>()).ToList();

--- a/src/Rdd.Infra/Storage/EventProcessableUnitOfWork.cs
+++ b/src/Rdd.Infra/Storage/EventProcessableUnitOfWork.cs
@@ -62,10 +62,5 @@ namespace Rdd.Infra.Storage
                 }
             }
         }
-
-        public void Dispose()
-        {
-            _dbContext.Dispose();
-        }
     }
 }

--- a/src/Rdd.Infra/Storage/HookedUnitOfWork.cs
+++ b/src/Rdd.Infra/Storage/HookedUnitOfWork.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data.SqlClient;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Rdd.Application;
@@ -7,20 +9,39 @@ using Rdd.Infra.Exceptions;
 
 namespace Rdd.Infra.Storage
 {
-    public class UnitOfWork : IUnitOfWork
+    public class HookedUnitOfWork : IUnitOfWork
     {
         private readonly DbContext _dbContext;
+        private readonly List<ISaveEventProcessor> _saveEventProcessors;
 
-        public UnitOfWork(DbContext dbContext)
+        public HookedUnitOfWork(DbContext dbContext, IEnumerable<ISaveEventProcessor> saveEventProcessors)
         {
             _dbContext = dbContext;
+            _saveEventProcessors = (saveEventProcessors ?? Enumerable.Empty<ISaveEventProcessor>()).ToList();
         }
 
         public async Task SaveChangesAsync()
         {
             try
             {
+                var processed = new List<(ISaveEventProcessor processor, ISavedEntries saved)>(_saveEventProcessors.Count);
+
+                foreach (var processor in _saveEventProcessors)
+                {
+                    var toSave = await processor.InternalBeforeSaveChangesAsync(_dbContext.ChangeTracker);
+                    if (toSave.PendingChangesCount != 0)
+                    {
+                        processed.Add((processor, toSave));
+                    }
+                }
+
                 await _dbContext.SaveChangesAsync();
+
+                foreach (var savedEvent in processed)
+                {
+                    await savedEvent.processor.InternalAfterSaveChangesAsync(savedEvent.saved);
+                }
+
             }
             catch (DbUpdateException ex)
             {

--- a/src/Rdd.Infra/Storage/IOnSaveChangesAsync.cs
+++ b/src/Rdd.Infra/Storage/IOnSaveChangesAsync.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+
+namespace Rdd.Infra.Storage
+{
+    /// <summary>
+    /// Interface to implement in order to plug hooks around Before/After SaveChangesAsync()
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IOnSaveChangesAsync<T> where T : class
+    {
+        /// <summary>
+        /// Called before SaveChangesAsync(), last opportunity to modify entities
+        /// </summary>
+        Task OnBeforeSaveAsync(SavedEntries<T> savedEntries);
+
+        /// <summary>
+        /// Called after SaveChangesAsync(), should be used to apply custom modifications before items are returned via API
+        /// </summary>
+        Task OnAfterSaveAsync(SavedEntries<T> savedEntries);
+    }
+}

--- a/src/Rdd.Infra/Storage/IOnSaveChangesAsync.cs
+++ b/src/Rdd.Infra/Storage/IOnSaveChangesAsync.cs
@@ -6,7 +6,7 @@ namespace Rdd.Infra.Storage
     /// Interface to implement in order to plug hooks around Before/After SaveChangesAsync()
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public interface IOnSaveChangesAsync<T> where T : class
+    public interface IOnSaveChangesHookAsync<T> where T : class
     {
         /// <summary>
         /// Called before SaveChangesAsync(), last opportunity to modify entities

--- a/src/Rdd.Infra/Storage/SaveEventProcessor.cs
+++ b/src/Rdd.Infra/Storage/SaveEventProcessor.cs
@@ -6,8 +6,15 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace Rdd.Infra.Storage
 {
-    public abstract class SaveEventProcessor<T> : ISaveEventProcessor where T : class
+    public sealed class SaveEventProcessor<T> : ISaveEventProcessor where T : class
     {
+        private readonly IOnSaveChangesAsync<T> _onSaveChangesHook;
+
+        public SaveEventProcessor(IOnSaveChangesAsync<T> onSaveChangesHook)
+        {
+            _onSaveChangesHook = onSaveChangesHook;
+        }
+
         public async Task<ISavedEntries> InternalBeforeSaveChangesAsync(ChangeTracker changeTracker)
         {
             IEnumerable<EntityEntry<T>> entityEntries = changeTracker.Entries<T>().ToList();
@@ -24,21 +31,14 @@ namespace Rdd.Infra.Storage
                 return payload;
             }
 
-            await OnBeforeSaveAsync(payload);
-
+            await _onSaveChangesHook.OnBeforeSaveAsync(payload);
+            
             return payload;
         }
 
-        public Task InternalAfterSaveChangesAsync(ISavedEntries savedEntries) => OnAfterSaveAsync(savedEntries as SavedEntries<T>);
-
-        /// <summary>
-        /// Called before SaveChangesAsync(), last opportunity to modify entities
-        /// </summary>
-        protected abstract Task OnBeforeSaveAsync(SavedEntries<T> savedEntries);
-
-        /// <summary>
-        /// Called after SaveChangesAsync(), should be used to apply custom modifications before items are returned via API
-        /// </summary>
-        protected abstract Task OnAfterSaveAsync(SavedEntries<T> savedEntries);
+        public async Task InternalAfterSaveChangesAsync(ISavedEntries savedEntries)
+        {
+            await _onSaveChangesHook.OnAfterSaveAsync(savedEntries as SavedEntries<T>);
+        }
     }
 }

--- a/src/Rdd.Infra/Storage/SaveEventProcessor.cs
+++ b/src/Rdd.Infra/Storage/SaveEventProcessor.cs
@@ -8,9 +8,9 @@ namespace Rdd.Infra.Storage
 {
     public sealed class SaveEventProcessor<T> : ISaveEventProcessor where T : class
     {
-        private readonly IOnSaveChangesAsync<T> _onSaveChangesHook;
+        private readonly IOnSaveChangesHookAsync<T> _onSaveChangesHook;
 
-        public SaveEventProcessor(IOnSaveChangesAsync<T> onSaveChangesHook)
+        public SaveEventProcessor(IOnSaveChangesHookAsync<T> onSaveChangesHook)
         {
             _onSaveChangesHook = onSaveChangesHook;
         }

--- a/src/Rdd.Infra/Storage/UnitOfWork.cs
+++ b/src/Rdd.Infra/Storage/UnitOfWork.cs
@@ -41,10 +41,5 @@ namespace Rdd.Infra.Storage
                 }
             }
         }
-
-        public void Dispose()
-        {
-            _dbContext.Dispose();
-        }
     }
 }

--- a/src/Rdd.Web/Helpers/RddBuilderExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddBuilderExtensions.cs
@@ -8,6 +8,7 @@ using Rdd.Domain.Patchers;
 using Rdd.Domain.Rights;
 using Rdd.Web.Models;
 using System;
+using Rdd.Infra.Storage;
 
 namespace Rdd.Web.Helpers
 {
@@ -118,6 +119,16 @@ namespace Rdd.Web.Helpers
                 .AddSingleton<IPatcher<T>, TPatcher>(s => s.GetRequiredService<TPatcher>())
                 .AddSingleton<TPatcher>();
 
+            return rddBuilder;
+        }
+
+        public static RddBuilder AddOnSaveChangesEvent<TOnSaveChanges, T>(this RddBuilder rddBuilder)
+            where TOnSaveChanges : class, IOnSaveChangesAsync<T>
+            where T : class
+        {
+            rddBuilder.Services.AddScoped<IUnitOfWork, HookedUnitOfWork>();
+            rddBuilder.Services.AddScoped<ISaveEventProcessor, SaveEventProcessor<T>>();
+            rddBuilder.Services.AddScoped<IOnSaveChangesAsync<T>, TOnSaveChanges>();
             return rddBuilder;
         }
 

--- a/src/Rdd.Web/Helpers/RddBuilderExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddBuilderExtensions.cs
@@ -122,13 +122,13 @@ namespace Rdd.Web.Helpers
             return rddBuilder;
         }
 
-        public static RddBuilder AddOnSaveChangesEvent<TOnSaveChanges, T>(this RddBuilder rddBuilder)
-            where TOnSaveChanges : class, IOnSaveChangesAsync<T>
+        public static RddBuilder AddOnSaveChangesHook<TOnSaveChanges, T>(this RddBuilder rddBuilder)
+            where TOnSaveChanges : class, IOnSaveChangesHookAsync<T>
             where T : class
         {
-            rddBuilder.Services.AddScoped<IUnitOfWork, HookedUnitOfWork>();
+            rddBuilder.Services.AddScoped<IUnitOfWork, EventProcessableUnitOfWork>();
             rddBuilder.Services.AddScoped<ISaveEventProcessor, SaveEventProcessor<T>>();
-            rddBuilder.Services.AddScoped<IOnSaveChangesAsync<T>, TOnSaveChanges>();
+            rddBuilder.Services.AddScoped<IOnSaveChangesHookAsync<T>, TOnSaveChanges>();
             return rddBuilder;
         }
 

--- a/test/Rdd.Infra.Tests/CollectionTests.cs
+++ b/test/Rdd.Infra.Tests/CollectionTests.cs
@@ -22,7 +22,7 @@ namespace Rdd.Infra.Tests
         {
             await RunCodeInsideIsolatedDatabaseAsync(async (context) =>
             {
-                var unitOfWork = new UnitOfWork(context, null);
+                var unitOfWork = new UnitOfWork(context);
                 var storage = new EFStorageService(context);
                 var repo = new UsersRepository(storage, _fixture.RightsService);
                 var collection = new UsersCollection(repo, _fixture.PatcherProvider, _fixture.Instanciator);
@@ -43,7 +43,7 @@ namespace Rdd.Infra.Tests
         {
             await RunCodeInsideIsolatedDatabaseAsync(async (context) =>
             {
-                var unitOfWork = new UnitOfWork(context, null);
+                var unitOfWork = new UnitOfWork(context);
                 var storage = new EFStorageService(context);
                 var repo = new UsersRepository(storage, _fixture.RightsService);
                 var collection = new UsersCollection(repo, _fixture.PatcherProvider, _fixture.Instanciator);

--- a/test/Rdd.Web.Tests/BeforeAfterSaveChangesValidation.cs
+++ b/test/Rdd.Web.Tests/BeforeAfterSaveChangesValidation.cs
@@ -37,8 +37,8 @@ namespace Rdd.Web.Tests
                     rdd.PagingMaximumLimit = 4242;
                 })
                 .WithDefaultRights(RightDefaultMode.Open)
-                .AddOnSaveChangesEvent<OnExchangeRateSave, ExchangeRate>()
-                .AddOnSaveChangesEvent<OnAnotherUserSave, AnotherUser>();
+                .AddOnSaveChangesHook<OnExchangeRateSave, ExchangeRate>()
+                .AddOnSaveChangesHook<OnAnotherUserSave, AnotherUser>();
 
             var provider = services.BuildServiceProvider();
 
@@ -47,8 +47,8 @@ namespace Rdd.Web.Tests
 
             ExchangeRate created = await app.CreateAsync(create, new Query<ExchangeRate>());
 
-            var onSave = provider.GetRequiredService<IOnSaveChangesAsync<ExchangeRate>>() as IOnSaveCount;
-            var onAnotherSave = provider.GetRequiredService<IOnSaveChangesAsync<AnotherUser>>() as IOnSaveCount;
+            var onSave = provider.GetRequiredService<IOnSaveChangesHookAsync<ExchangeRate>>() as IOnSaveCount;
+            var onAnotherSave = provider.GetRequiredService<IOnSaveChangesHookAsync<AnotherUser>>() as IOnSaveCount;
 
             Assert.Equal(2, onSave.AddCount);
             Assert.Equal(0, onSave.UpdateCount);
@@ -94,7 +94,7 @@ namespace Rdd.Web.Tests
         int CallsCount { get; }
     }
 
-    public class SaveEventProcessorMock<T> : IOnSaveChangesAsync<T>, IOnSaveCount where T : class
+    public class SaveEventProcessorMock<T> : IOnSaveChangesHookAsync<T>, IOnSaveCount where T : class
     {
         public int AddCount { get; private set; } = 0;
         public int UpdateCount { get; private set; } = 0;

--- a/test/Rdd.Web.Tests/BeforeAfterSaveChangesValidation.cs
+++ b/test/Rdd.Web.Tests/BeforeAfterSaveChangesValidation.cs
@@ -29,18 +29,16 @@ namespace Rdd.Web.Tests
         public async Task MultipleImplementations()
         {
             var services = new ServiceCollection();
+
             services.AddDbContext<ExchangeRateDbContext>((service, options) => { options.UseInMemoryDatabase("BeforeAfterSave"); });
             services.AddRdd<ExchangeRateDbContext>(rdd =>
                 {
                     rdd.PagingLimit = 10;
                     rdd.PagingMaximumLimit = 4242;
                 })
-                .WithDefaultRights(RightDefaultMode.Open);
-
-            services.AddScoped<OnExchangeRateSave>();
-            services.AddScoped<OnAnotherUserSave>();
-            services.AddScoped<ISaveEventProcessor>(s => s.GetRequiredService<OnExchangeRateSave>());
-            services.AddScoped<ISaveEventProcessor>(s => s.GetRequiredService<OnAnotherUserSave>());
+                .WithDefaultRights(RightDefaultMode.Open)
+                .AddOnSaveChangesEvent<OnExchangeRateSave, ExchangeRate>()
+                .AddOnSaveChangesEvent<OnAnotherUserSave, AnotherUser>();
 
             var provider = services.BuildServiceProvider();
 
@@ -49,14 +47,14 @@ namespace Rdd.Web.Tests
 
             ExchangeRate created = await app.CreateAsync(create, new Query<ExchangeRate>());
 
-            var onSave = provider.GetRequiredService<OnExchangeRateSave>();
-            var onAnotherSave = provider.GetRequiredService<OnAnotherUserSave>();
+            var onSave = provider.GetRequiredService<IOnSaveChangesAsync<ExchangeRate>>() as IOnSaveCount;
+            var onAnotherSave = provider.GetRequiredService<IOnSaveChangesAsync<AnotherUser>>() as IOnSaveCount;
 
             Assert.Equal(2, onSave.AddCount);
             Assert.Equal(0, onSave.UpdateCount);
             Assert.Equal(0, onSave.DeleteCount);
             Assert.Equal(2, onSave.CallsCount);
-            
+
             Assert.Equal(0, onAnotherSave.AddCount);
             Assert.Equal(0, onAnotherSave.UpdateCount);
             Assert.Equal(0, onAnotherSave.DeleteCount);
@@ -64,13 +62,13 @@ namespace Rdd.Web.Tests
 
             var update = new CandidateParser(new JsonParser(), new OptionsAccessor()).Parse<ExchangeRate, int>(@"{ ""name"": ""other name"" }");
             var updated = await app.UpdateByIdAsync(created.Id, update, new Query<ExchangeRate>());
-             
+
             Assert.Equal(2, onSave.AddCount);
             Assert.Equal(2, onSave.UpdateCount);
             Assert.Equal(0, onSave.DeleteCount);
             Assert.Equal(4, onSave.CallsCount);
 
-            await app.DeleteByIdAsync(updated.Id); 
+            await app.DeleteByIdAsync(updated.Id);
 
             Assert.Equal(2, onSave.AddCount);
             Assert.Equal(2, onSave.UpdateCount);
@@ -88,21 +86,28 @@ namespace Rdd.Web.Tests
     public class OnAnotherUserSave : SaveEventProcessorMock<AnotherUser>
     {
     }
-    
-    public class SaveEventProcessorMock<T> : SaveEventProcessor<T> where T : class
+
+    public interface IOnSaveCount {
+        int AddCount { get; }
+        int UpdateCount { get; }
+        int DeleteCount { get; }
+        int CallsCount { get; }
+    }
+
+    public class SaveEventProcessorMock<T> : IOnSaveChangesAsync<T>, IOnSaveCount where T : class
     {
         public int AddCount { get; private set; } = 0;
         public int UpdateCount { get; private set; } = 0;
         public int DeleteCount { get; private set; } = 0;
         public int CallsCount { get; private set; } = 0;
 
-        protected override Task OnBeforeSaveAsync(SavedEntries<T> savedEntries)
+        public Task OnBeforeSaveAsync(SavedEntries<T> savedEntries)
         {
             UpdateStats(savedEntries);
             return Task.CompletedTask;
         }
 
-        protected override Task OnAfterSaveAsync(SavedEntries<T> savedEntries)
+        public Task OnAfterSaveAsync(SavedEntries<T> savedEntries)
         {
             UpdateStats(savedEntries);
             return Task.CompletedTask;

--- a/test/Rdd.Web.Tests/WebControllerTests.cs
+++ b/test/Rdd.Web.Tests/WebControllerTests.cs
@@ -10,25 +10,24 @@ namespace Rdd.Web.Tests
 {
     public class WebControllerTests
     {
-     
+
         [Fact]
         public async Task WebControllerShouldWorkOnInterfaces()
         {
-            using (var storage = new InMemoryStorageService())
-            {
-                var repository = new Repository<IUser>(storage, null);
-                var collection = new ReadOnlyRestCollection<IUser, int>(repository);
-                var appController = new ReadOnlyAppController<IUser, int>(collection);
+            var storage = new InMemoryStorageService();
 
-                repository.Add(new User { Id = 1 });
-                repository.Add(new AnotherUser { Id = 2 });
+            var repository = new Repository<IUser>(storage, null);
+            var collection = new ReadOnlyRestCollection<IUser, int>(repository);
+            var appController = new ReadOnlyAppController<IUser, int>(collection);
 
-                var controller = new UserWebController(appController, QueryParserHelper.GetQueryParser<IUser>());
+            repository.Add(new User { Id = 1 });
+            repository.Add(new AnotherUser { Id = 2 });
 
-                var results = await controller.GetEnumerableAsync(); //Simplified equivalent to GetAsync()
+            var controller = new UserWebController(appController, QueryParserHelper.GetQueryParser<IUser>());
 
-                Assert.Equal(2, results.Count());
-            }
+            var results = await controller.GetEnumerableAsync(); //Simplified equivalent to GetAsync()
+
+            Assert.Equal(2, results.Count());
         }
     }
 }


### PR DESCRIPTION
Resolve https://github.com/LuccaSA/RestDrivenDomain/issues/255

- On passe maintenant par un IOnSaveChangesAsync pour register des hooks, plus propre que SaveEventProcessor
- Register des IOnSaveChangesAsync via RddBuilder
- UnitOfWork dans hooks mise à disposition pour les projets n'utilisant pas de hooks