### PR TITLE
try fix sonar

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ before_build:
     IF "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (
     dotnet sonarscanner begin /k:"RestDrivenDomain" /d:"sonar.analysis.mode=publish" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.organization=luccaintegration-github" /d:"sonar.login=%SONAR_TOKEN%" /d:sonar.cs.opencover.reportsPaths="coverage-opencover.xml"
     ) ELSE (
-    dotnet sonarscanner begin /k:"RestDrivenDomain" /d:"sonar.analysis.mode=preview" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.organization=luccaintegration-github" /d:"sonar.login=%SONAR_TOKEN%" /d:"sonar.github.pullRequest=%APPVEYOR_PULL_REQUEST_NUMBER%" /d:"sonar.github.repository=LuccaSA/RestDrivenDomain" /d:"sonar.github.oauth=%GITHUB_ACCESS_TOKEN%"
+    dotnet sonarscanner begin /k:"RestDrivenDomain" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.organization=luccaintegration-github" /d:"sonar.login=%SONAR_TOKEN%" /d:"sonar.github.oauth=%GITHUB_ACCESS_TOKEN%" /d:"sonar.pullrequest.provider=github" /d:"sonar.pullrequest.branch=%APPVEYOR_REPO_BRANCH%" /d:"sonar.pullrequest.key=%APPVEYOR_PULL_REQUEST_NUMBER%" /d:"sonar.pullrequest.github.repository=LuccaSA/RestDrivenDomain" /d:"sonar.pullrequest.github.endpoint=https://api.github.com"
     )
 
 build_script:


### PR DESCRIPTION
Sonar a droppé la feature GRATUITE de PR-analysis, et bascule en 7.4 sur les short-lived et long-lived branch analysis, feature PAYANTE dans la developper edition.

La feature est dispo sur sonarcloud.io en gratuit, mais en interne il nous faudra payer une petite fortune juste pour cette feature... Donc NO GO.

En attendant, voici, sonar est "rétablit" sur le repo...