### PR TITLE
Transformation de la query via interface (annule et remplace https://github.com/LuccaSA/RestDrivenDomain/pull/261)

### DIFF
--- a/src/RDD.Domain/Models/Querying/IQuery.cs
+++ b/src/RDD.Domain/Models/Querying/IQuery.cs
@@ -1,0 +1,17 @@
+﻿using Rdd.Domain.Helpers;
+using Rdd.Domain.Helpers.Expressions;
+using System.Collections.Generic;
+
+namespace Rdd.Domain.Models.Querying
+{
+    public interface IQuery<TEntity>
+        where TEntity : class
+    {
+        HttpVerbs Verb { get; }
+        IExpressionTree<TEntity> Fields { get; }
+        Filter<TEntity> Filter { get; }
+        List<OrderBy<TEntity>> OrderBys { get; }
+        Page Page { get; }
+        Options Options { get; }
+    }
+}

--- a/src/Rdd.Application/Controllers/AppController.cs
+++ b/src/Rdd.Application/Controllers/AppController.cs
@@ -29,43 +29,43 @@ namespace Rdd.Application.Controllers
             _unitOfWork = unitOfWork;
         }
 
-        public virtual async Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query)
+        public virtual async Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, IQuery<TEntity> query)
         {
             var entity = await Collection.CreateAsync(candidate, query);
             await SaveChangesAsync();
             return entity;
         }
 
-        public virtual async Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query)
+        public virtual async Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, IQuery<TEntity> query)
         {
             var entities = await Collection.CreateAsync(candidates, query);
             await SaveChangesAsync();
             return entities;
         }
 
-        public virtual async Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query)
+        public virtual async Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, IQuery<TEntity> query)
         {
             var entity = await Collection.UpdateByIdAsync(id, candidate, query);
             await SaveChangesAsync();
             return entity;
         }
 
-        public virtual async Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, ICandidate<TEntity, TKey>> candidatesByIds, Query<TEntity> query)
+        public virtual async Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, ICandidate<TEntity, TKey>> candidatesByIds, IQuery<TEntity> query)
         {
             var entities = await Collection.UpdateByIdsAsync(candidatesByIds, query);
             await SaveChangesAsync();
             return entities;
         }
 
-        public async Task DeleteByIdAsync(TKey id)
+        public async Task DeleteByIdAsync(TKey id, IQuery<TEntity> query)
         {
-            await Collection.DeleteByIdAsync(id);
+            await Collection.DeleteByIdAsync(id, query);
             await SaveChangesAsync();
         }
 
-        public async Task DeleteByIdsAsync(IEnumerable<TKey> ids)
+        public async Task DeleteByIdsAsync(IEnumerable<TKey> ids, IQuery<TEntity> query)
         {
-            await Collection.DeleteByIdsAsync(ids);
+            await Collection.DeleteByIdsAsync(ids, query);
             await SaveChangesAsync();
         }
          

--- a/src/Rdd.Application/Controllers/ReadOnlyAppController.cs
+++ b/src/Rdd.Application/Controllers/ReadOnlyAppController.cs
@@ -27,9 +27,9 @@ namespace Rdd.Application.Controllers
             Collection = collection;
         }
 
-        public virtual Task<ISelection<TEntity>> GetAsync(Query<TEntity> query) => Collection.GetAsync(query);
+        public virtual Task<ISelection<TEntity>> GetAsync(IQuery<TEntity> query) => Collection.GetAsync(query);
 
-        public virtual Task<TEntity> GetByIdAsync(TKey id, Query<TEntity> query) => Collection.GetByIdAsync(id, query);
+        public virtual Task<TEntity> GetByIdAsync(TKey id, IQuery<TEntity> query) => Collection.GetByIdAsync(id, query);
 
 
     }

--- a/src/Rdd.Application/IAppController.cs
+++ b/src/Rdd.Application/IAppController.cs
@@ -10,13 +10,13 @@ namespace Rdd.Application
         where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
-        Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query);
-        Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query);
+        Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, IQuery<TEntity> query);
+        Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, IQuery<TEntity> query);
 
-        Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query);
-        Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, ICandidate<TEntity, TKey>> candidatesByIds, Query<TEntity> query);
+        Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, IQuery<TEntity> query);
+        Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, ICandidate<TEntity, TKey>> candidatesByIds, IQuery<TEntity> query);
 
-        Task DeleteByIdAsync(TKey id);
-        Task DeleteByIdsAsync(IEnumerable<TKey> ids);
+        Task DeleteByIdAsync(TKey id, IQuery<TEntity> query);
+        Task DeleteByIdsAsync(IEnumerable<TKey> ids, IQuery<TEntity> query);
     }
 }

--- a/src/Rdd.Application/IReadOnlyAppController.cs
+++ b/src/Rdd.Application/IReadOnlyAppController.cs
@@ -9,7 +9,7 @@ namespace Rdd.Application
         where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
-        Task<ISelection<TEntity>> GetAsync(Query<TEntity> query);
-        Task<TEntity> GetByIdAsync(TKey id, Query<TEntity> query);
+        Task<ISelection<TEntity>> GetAsync(IQuery<TEntity> query);
+        Task<TEntity> GetByIdAsync(TKey id, IQuery<TEntity> query);
     }
 }

--- a/src/Rdd.Domain/IReadOnlyRepository.cs
+++ b/src/Rdd.Domain/IReadOnlyRepository.cs
@@ -1,14 +1,17 @@
 ﻿using Rdd.Domain.Models.Querying;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Rdd.Domain
 {
-    public interface IReadOnlyRepository<TEntity>
-        where TEntity : class
+    public interface IReadOnlyRepository<TEntity, TKey>
+        where TEntity : class, IPrimaryKey<TKey>
+        where TKey : IEquatable<TKey>
     {
-        Task<int> CountAsync(Query<TEntity> query);
-        Task<IEnumerable<TEntity>> GetAsync(Query<TEntity> query);
-        Task<IEnumerable<TEntity>> PrepareAsync(IEnumerable<TEntity> entities, Query<TEntity> query);
+        Task<int> CountAsync(IQuery<TEntity> query);
+        Task<ISelection<TEntity>> GetAsync(IQuery<TEntity> query);
+        Task<TEntity> GetByIdAsync(TKey id, IQuery<TEntity> query);
+        Task<IEnumerable<TEntity>> GetByIdsAsync(IEnumerable<TKey> ids, IQuery<TEntity> query);
     }
 }

--- a/src/Rdd.Domain/IReadOnlyRestCollection.cs
+++ b/src/Rdd.Domain/IReadOnlyRestCollection.cs
@@ -8,8 +8,7 @@ namespace Rdd.Domain
         where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
-        Task<ISelection<TEntity>> GetAsync(Query<TEntity> query);
-        Task<bool> AnyAsync(Query<TEntity> query);
-        Task<TEntity> GetByIdAsync(TKey id, Query<TEntity> query);
+        Task<ISelection<TEntity>> GetAsync(IQuery<TEntity> query);
+        Task<TEntity> GetByIdAsync(TKey id, IQuery<TEntity> query);
     }
 }

--- a/src/Rdd.Domain/IRepository.cs
+++ b/src/Rdd.Domain/IRepository.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Rdd.Domain
 {
-    public interface IRepository<TEntity> : IReadOnlyRepository<TEntity>
-        where TEntity : class
+    public interface IRepository<TEntity, TKey> : IReadOnlyRepository<TEntity, TKey>
+        where TEntity : class, IPrimaryKey<TKey>
+        where TKey : IEquatable<TKey>
     {
         void Add(TEntity entity);
         void AddRange(IEnumerable<TEntity> entities);

--- a/src/Rdd.Domain/IRestCollection.cs
+++ b/src/Rdd.Domain/IRestCollection.cs
@@ -9,13 +9,13 @@ namespace Rdd.Domain
         where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
-        Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null);
-        Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query = null);
+        Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, IQuery<TEntity> query = null);
+        Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, IQuery<TEntity> query = null);
 
-        Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null);
-        Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, ICandidate<TEntity, TKey>> candidatesByIds, Query<TEntity> query = null);
+        Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, IQuery<TEntity> query = null);
+        Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, ICandidate<TEntity, TKey>> candidatesByIds, IQuery<TEntity> query = null);
 
-        Task DeleteByIdAsync(TKey id);
-        Task DeleteByIdsAsync(IEnumerable<TKey> ids);
+        Task DeleteByIdAsync(TKey id, IQuery<TEntity> query);
+        Task DeleteByIdsAsync(IEnumerable<TKey> ids, IQuery<TEntity> query);
     }
 }

--- a/src/Rdd.Domain/Rights/ClosedRightExpressionsHelper.cs
+++ b/src/Rdd.Domain/Rights/ClosedRightExpressionsHelper.cs
@@ -7,6 +7,6 @@ namespace Rdd.Domain.Rights
     public class ClosedRightExpressionsHelper<T> : IRightExpressionsHelper<T>
          where T : class
     {
-        public Expression<Func<T, bool>> GetFilter(Query<T> query) => t => false;
+        public Expression<Func<T, bool>> GetFilter(IQuery<T> query) => t => false;
     }
 }

--- a/src/Rdd.Domain/Rights/IRightExpressionsHelper.cs
+++ b/src/Rdd.Domain/Rights/IRightExpressionsHelper.cs
@@ -7,6 +7,6 @@ namespace Rdd.Domain.Rights
     public interface IRightExpressionsHelper<T>
          where T : class
     {
-        Expression<Func<T, bool>> GetFilter(Query<T> query);
+        Expression<Func<T, bool>> GetFilter(IQuery<T> query);
     }
 }

--- a/src/Rdd.Domain/Rights/OpenRightExpressionsHelper.cs
+++ b/src/Rdd.Domain/Rights/OpenRightExpressionsHelper.cs
@@ -7,6 +7,6 @@ namespace Rdd.Domain.Rights
     public class OpenRightExpressionsHelper<T> : IRightExpressionsHelper<T>
          where T : class
     {
-        public Expression<Func<T, bool>> GetFilter(Query<T> query) => t => true;
+        public Expression<Func<T, bool>> GetFilter(IQuery<T> query) => t => true;
     }
 }

--- a/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
+++ b/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
@@ -1,16 +1,20 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Rdd.Domain;
 using Rdd.Domain.Helpers.Expressions;
+using Rdd.Domain.Models;
 using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Rights;
+using Rdd.Infra.Web.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace Rdd.Infra.Storage
 {
-    public class ReadOnlyRepository<TEntity> : IReadOnlyRepository<TEntity>
-        where TEntity : class
+    public class ReadOnlyRepository<TEntity, TKey> : IReadOnlyRepository<TEntity, TKey>
+        where TEntity : class, IPrimaryKey<TKey>
+        where TKey : IEquatable<TKey>
     {
         protected IStorageService StorageService { get; set; }
         protected IRightExpressionsHelper<TEntity> RightExpressionsHelper { get; set; }
@@ -24,7 +28,7 @@ namespace Rdd.Infra.Storage
         }
 
         public virtual Task<int> CountAsync() => CountAsync(new Query<TEntity>());
-        public virtual Task<int> CountAsync(Query<TEntity> query)
+        public virtual Task<int> CountAsync(IQuery<TEntity> query)
         {
             var entities = Set();
 
@@ -42,29 +46,67 @@ namespace Rdd.Infra.Storage
             return Task.FromResult(entities.Count());
         }
 
-        public virtual Task<IEnumerable<TEntity>> GetAsync(Query<TEntity> query)
+        public virtual async Task<TEntity> GetByIdAsync(TKey id, IQuery<TEntity> query)
         {
-            var entities = Set();
+            var clone = new Query<TEntity>(query, e => e.Id.Equals(id));
 
-            if (query.Options.CheckRights)
-            {
-                entities = ApplyRights(entities, query);
-            }
-
-            entities = ApplyFilters(entities, query);
-            entities = ApplyOrderBys(entities, query);
-
-            if (query.Page != Page.Unlimited)
-            {
-                entities = ApplyPage(entities, query);
-            }
-
-            entities = ApplyIncludes(entities, query);
-
-            return StorageService.EnumerateEntitiesAsync(entities);
+            return (await GetAsync(clone)).Items.FirstOrDefault();
         }
 
-        public virtual Task<IEnumerable<TEntity>> PrepareAsync(IEnumerable<TEntity> entities, Query<TEntity> query)
+        public virtual async Task<IEnumerable<TEntity>> GetByIdsAsync(IEnumerable<TKey> ids, IQuery<TEntity> query)
+        {
+            var clone = new Query<TEntity>(query, e => ids.Contains(e.Id));
+
+            return (await GetAsync(clone)).Items;
+        }
+        public virtual async Task<ISelection<TEntity>> GetAsync(IQuery<TEntity> query)
+        {
+            var count = 0;
+            IEnumerable<TEntity> items = new HashSet<TEntity>();
+
+            //Dans de rares cas on veut seulement le count des entités
+            if (query.Options.NeedCount && !query.Options.NeedEnumeration)
+            {
+                count = await CountAsync(query);
+            }
+
+            //En général on veut une énumération des entités
+            if (query.Options.NeedEnumeration)
+            {
+                var entities = Set();
+
+                if (query.Options.CheckRights)
+                {
+                    entities = ApplyRights(entities, query);
+                }
+
+                entities = ApplyFilters(entities, query);
+                entities = ApplyOrderBys(entities, query);
+
+                if (query.Page != Page.Unlimited)
+                {
+                    entities = ApplyPage(entities, query);
+                }
+
+                entities = ApplyIncludes(entities, query);
+
+                items = await StorageService.EnumerateEntitiesAsync(entities);
+
+                count = items.Count();
+
+                //Si y'a plus d'items que le paging max ou que l'offset du paging n'est pas à 0, il faut compter la totalité des entités
+                if (query.Page.Offset > 0 || query.Page.Limit <= count)
+                {
+                    count = await CountAsync(query);
+                }
+
+                items = await PrepareAsync(items, query);
+            }
+
+            return new Selection<TEntity>(items, count);
+        }
+
+        protected virtual Task<IEnumerable<TEntity>> PrepareAsync(IEnumerable<TEntity> entities, IQuery<TEntity> query)
         {
             return Task.FromResult(entities);
         }
@@ -74,11 +116,11 @@ namespace Rdd.Infra.Storage
             return StorageService.Set<TEntity>();
         }
 
-        protected virtual IQueryable<TEntity> ApplyRights(IQueryable<TEntity> entities, Query<TEntity> query)
+        protected virtual IQueryable<TEntity> ApplyRights(IQueryable<TEntity> entities, IQuery<TEntity> query)
         {
             return entities.Where(RightExpressionsHelper.GetFilter(query));
         }
-        protected virtual IQueryable<TEntity> ApplyFilters(IQueryable<TEntity> entities, Query<TEntity> query)
+        protected virtual IQueryable<TEntity> ApplyFilters(IQueryable<TEntity> entities, IQuery<TEntity> query)
         {
             if (query?.Filter?.Expression == null)
             {
@@ -87,7 +129,7 @@ namespace Rdd.Infra.Storage
             return entities.Where(query.Filter.Expression);
         }
 
-        protected virtual IQueryable<TEntity> ApplyOrderBys(IQueryable<TEntity> entities, Query<TEntity> query)
+        protected virtual IQueryable<TEntity> ApplyOrderBys(IQueryable<TEntity> entities, IQuery<TEntity> query)
         {
             foreach (var orderBy in query.OrderBys)
             {
@@ -96,12 +138,12 @@ namespace Rdd.Infra.Storage
 
             return entities;
         }
-        protected virtual IQueryable<TEntity> ApplyPage(IQueryable<TEntity> entities, Query<TEntity> query)
+        protected virtual IQueryable<TEntity> ApplyPage(IQueryable<TEntity> entities, IQuery<TEntity> query)
         {
             return entities.Skip(query.Page.Offset).Take(query.Page.Limit);
         }
 
-        protected virtual IQueryable<TEntity> ApplyIncludes(IQueryable<TEntity> entities, Query<TEntity> query)
+        protected virtual IQueryable<TEntity> ApplyIncludes(IQueryable<TEntity> entities, IQuery<TEntity> query)
         {
             if (IncludeWhiteList == null || query.Fields == null)
             {

--- a/src/Rdd.Infra/Storage/Repository.cs
+++ b/src/Rdd.Infra/Storage/Repository.cs
@@ -1,11 +1,13 @@
 ﻿using Rdd.Domain;
 using Rdd.Domain.Rights;
+using System;
 using System.Collections.Generic;
 
 namespace Rdd.Infra.Storage
 {
-    public class Repository<TEntity> : ReadOnlyRepository<TEntity>, IRepository<TEntity>
-        where TEntity : class
+    public class Repository<TEntity, TKey> : ReadOnlyRepository<TEntity, TKey>, IRepository<TEntity, TKey>
+        where TEntity : class, IPrimaryKey<TKey>
+        where TKey : IEquatable<TKey>
     {
         public Repository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightExpressionsHelper)
             : base(storageService, rightExpressionsHelper) { }

--- a/src/Rdd.Infra/Web/Models/Query.cs
+++ b/src/Rdd.Infra/Web/Models/Query.cs
@@ -1,12 +1,13 @@
 ﻿using Rdd.Domain.Helpers;
 using Rdd.Domain.Helpers.Expressions;
+using Rdd.Domain.Models.Querying;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace Rdd.Domain.Models.Querying
+namespace Rdd.Infra.Web.Models
 {
-    public class Query<TEntity>
+    public class Query<TEntity> : IQuery<TEntity>
         where TEntity : class
     {
         public HttpVerbs Verb { get; set; }
@@ -42,7 +43,7 @@ namespace Rdd.Domain.Models.Querying
             Filter = filter;
         }
 
-        public Query(Query<TEntity> source)
+        public Query(IQuery<TEntity> source)
             : this()
         {
             Verb = source.Verb;
@@ -53,7 +54,7 @@ namespace Rdd.Domain.Models.Querying
             Options = source.Options;
         }
 
-        public Query(Query<TEntity> source, Expression<Func<TEntity, bool>> filter)
+        public Query(IQuery<TEntity> source, Expression<Func<TEntity, bool>> filter)
             : this(source)
         {
             Filter = new Filter<TEntity>(filter);

--- a/src/Rdd.Web/Controllers/ReadOnlyWebController.cs
+++ b/src/Rdd.Web/Controllers/ReadOnlyWebController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Rdd.Application;
 using Rdd.Domain;
 using Rdd.Domain.Helpers;
-using Rdd.Domain.Models.Querying;
+using Rdd.Infra.Web.Models;
 using Rdd.Web.Querying;
 using Rdd.Web.Serialization;
 using System;

--- a/src/Rdd.Web/Controllers/WebController.cs
+++ b/src/Rdd.Web/Controllers/WebController.cs
@@ -5,6 +5,7 @@ using Rdd.Domain;
 using Rdd.Domain.Helpers;
 using Rdd.Domain.Models;
 using Rdd.Domain.Models.Querying;
+using Rdd.Infra.Web.Models;
 using Rdd.Web.Querying;
 using Rdd.Web.Serialization;
 using System;
@@ -104,7 +105,8 @@ namespace Rdd.Web.Controllers
                 return new StatusCodeResult(StatusCodes.Status405MethodNotAllowed);
             }
 
-            await AppController.DeleteByIdAsync(id);
+            Query<TEntity> query = QueryParser.Parse(HttpContext.Request, false);
+            await AppController.DeleteByIdAsync(id, query);
 
             return Ok();
         }
@@ -124,7 +126,8 @@ namespace Rdd.Web.Controllers
                 return BadRequest("To delete a collection of entities, provide an array of objets with an 'id' property");
             }
 
-            await AppController.DeleteByIdsAsync(candidates.Select(c => c.Id));
+            Query<TEntity> query = QueryParser.Parse(HttpContext.Request, true);
+            await AppController.DeleteByIdsAsync(candidates.Select(c => c.Id), query);
 
             return Ok();
         }

--- a/src/Rdd.Web/Helpers/RddBuilderExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddBuilderExtensions.cs
@@ -37,24 +37,26 @@ namespace Rdd.Web.Helpers
             return rddBuilder;
         }
 
-        public static RddBuilder AddReadOnlyRepository<TRepository, TEntity>(this RddBuilder rddBuilder)
-            where TRepository : class, IReadOnlyRepository<TEntity>
-            where TEntity : class
+        public static RddBuilder AddReadOnlyRepository<TRepository, TEntity, TKey>(this RddBuilder rddBuilder)
+            where TRepository : class, IReadOnlyRepository<TEntity, TKey>
+            where TEntity : class, IPrimaryKey<TKey>
+            where TKey : IEquatable<TKey>
         {
             rddBuilder.Services
-                .AddScoped<IReadOnlyRepository<TEntity>, TRepository>(s => s.GetRequiredService<TRepository>())
+                .AddScoped<IReadOnlyRepository<TEntity, TKey>, TRepository>(s => s.GetRequiredService<TRepository>())
                 .AddScoped<TRepository>();
 
             return rddBuilder;
         }
 
-        public static RddBuilder AddRepository<TRepository, TEntity>(this RddBuilder rddBuilder)
-            where TRepository : class, IRepository<TEntity>
-            where TEntity : class
+        public static RddBuilder AddRepository<TRepository, TEntity, TKey>(this RddBuilder rddBuilder)
+            where TRepository : class, IRepository<TEntity, TKey>
+            where TEntity : class, IPrimaryKey<TKey>
+            where TKey : IEquatable<TKey>
         {
             rddBuilder.Services
-                .AddScoped<IRepository<TEntity>, TRepository>(s => s.GetRequiredService<TRepository>())
-                .AddScoped<IReadOnlyRepository<TEntity>, TRepository>(s => s.GetRequiredService<TRepository>())
+                .AddScoped<IRepository<TEntity, TKey>, TRepository>(s => s.GetRequiredService<TRepository>())
+                .AddScoped<IReadOnlyRepository<TEntity, TKey>, TRepository>(s => s.GetRequiredService<TRepository>())
                 .AddScoped<TRepository>();
 
             return rddBuilder;

--- a/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -77,8 +77,8 @@ namespace Rdd.Web.Helpers
             services.TryAddScoped<IStorageService, EFStorageService>();
             services.TryAddScoped<IUnitOfWork, UnitOfWork>();
 
-            services.TryAddScoped(typeof(IReadOnlyRepository<>), typeof(ReadOnlyRepository<>));
-            services.TryAddScoped(typeof(IRepository<>), typeof(Repository<>));
+            services.TryAddScoped(typeof(IReadOnlyRepository<,>), typeof(ReadOnlyRepository<,>));
+            services.TryAddScoped(typeof(IRepository<,>), typeof(Repository<,>));
             services.TryAddScoped(typeof(IReadOnlyRestCollection<,>), typeof(ReadOnlyRestCollection<,>));
             services.TryAddScoped(typeof(IRestCollection<,>), typeof(RestCollection<,>));
             services.TryAddScoped(typeof(IReadOnlyAppController<,>), typeof(ReadOnlyAppController<,>));

--- a/src/Rdd.Web/Querying/IQueryParser.cs
+++ b/src/Rdd.Web/Querying/IQueryParser.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
-using Rdd.Domain.Models.Querying;
+using Rdd.Infra.Web.Models;
 
 namespace Rdd.Web.Querying
 {

--- a/src/Rdd.Web/Querying/QueryParser.cs
+++ b/src/Rdd.Web/Querying/QueryParser.cs
@@ -2,8 +2,8 @@
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Rdd.Domain;
 using Rdd.Domain.Helpers;
-using Rdd.Domain.Models.Querying;
 using Rdd.Infra.Helpers;
+using Rdd.Infra.Web.Models;
 using System;
 
 namespace Rdd.Web.Querying

--- a/test/Rdd.Domain.Tests/AbstractEntityTests.cs
+++ b/test/Rdd.Domain.Tests/AbstractEntityTests.cs
@@ -1,8 +1,8 @@
 ﻿using Rdd.Domain.Models;
-using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Rights;
 using Rdd.Domain.Tests.Models;
 using Rdd.Infra.Storage;
+using Rdd.Infra.Web.Models;
 using System.Linq;
 using Xunit;
 
@@ -10,13 +10,13 @@ namespace Rdd.Domain.Tests
 {
     internal class AbstractClassCollection : ReadOnlyRestCollection<AbstractClass, int>
     {
-        public AbstractClassCollection(IRepository<AbstractClass> repository)
+        public AbstractClassCollection(IRepository<AbstractClass, int> repository)
             : base(repository) { }
     }
 
     internal class ConcreteClassThreeCollection : ReadOnlyRestCollection<ConcreteClassThree, int>
     {
-        public ConcreteClassThreeCollection(IRepository<ConcreteClassThree> repository)
+        public ConcreteClassThreeCollection(IRepository<ConcreteClassThree, int> repository)
             : base(repository) { }
     }
 
@@ -27,7 +27,7 @@ namespace Rdd.Domain.Tests
         {
             var rightsService = new OpenRightExpressionsHelper<ConcreteClassThree>();
             var storage = new InMemoryStorageService();
-            var repo = new OpenRepository<ConcreteClassThree>(storage, rightsService);
+            var repo = new OpenRepository<ConcreteClassThree, int>(storage, rightsService);
 
             repo.Add(new ConcreteClassThree());
             repo.Add(new ConcreteClassThree());
@@ -44,7 +44,7 @@ namespace Rdd.Domain.Tests
         {
             var rightsService = new OpenRightExpressionsHelper<AbstractClass>();
             var storage = new InMemoryStorageService();
-            var repo = new OpenRepository<AbstractClass>(storage, rightsService);
+            var repo = new OpenRepository<AbstractClass, int>(storage, rightsService);
 
             repo.Add(new ConcreteClassOne());
             repo.Add(new ConcreteClassOne());

--- a/test/Rdd.Domain.Tests/AppControllerTests.cs
+++ b/test/Rdd.Domain.Tests/AppControllerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Rdd.Domain.Json;
 using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Tests.Models;
+using Rdd.Infra.Web.Models;
 using Rdd.Web.Querying;
 using System;
 using System.Collections.Generic;

--- a/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
+++ b/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
@@ -6,11 +6,11 @@ using Rdd.Domain.Exceptions;
 using Rdd.Domain.Helpers.Reflection;
 using Rdd.Domain.Json;
 using Rdd.Domain.Models;
-using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Patchers;
 using Rdd.Domain.Rights;
 using Rdd.Domain.Tests.Models;
 using Rdd.Infra.Storage;
+using Rdd.Infra.Web.Models;
 using Rdd.Web.Models;
 using Rdd.Web.Querying;
 using System;
@@ -62,7 +62,7 @@ namespace Rdd.Domain.Tests
             rightService.Setup(s => s.GetFilter(It.IsAny<Query<User>>())).Returns(trueFilter);
 
             var id = Guid.NewGuid();
-            var repo = new Repository<User>(_fixture.InMemoryStorage, rightService.Object);
+            var repo = new Repository<User, Guid>(_fixture.InMemoryStorage, rightService.Object);
             var users = new UsersCollection(repo, _fixture.PatcherProvider, _fixture.Instanciator);
             var app = new UsersAppController(_fixture.InMemoryStorage, users);
             var candidate1 = _parser.Parse<User, Guid>($@"{{ ""id"": ""{id}"" }}");
@@ -97,7 +97,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task Post_SHOULD_work_WHEN_InstantiateEntityIsOverridenAndEntityHasParametersInConstructor()
         {
-            var repo = new Repository<UserWithParameters>(_fixture.InMemoryStorage, new OpenRightExpressionsHelper<UserWithParameters>());
+            var repo = new Repository<UserWithParameters, int>(_fixture.InMemoryStorage, new OpenRightExpressionsHelper<UserWithParameters>());
             var users = new UsersCollectionWithParameters(repo, _fixture.PatcherProvider, new InstanciatorImplementation());
             var query = new Query<UserWithParameters>();
             query.Options.CheckRights = false;
@@ -196,7 +196,7 @@ namespace Rdd.Domain.Tests
         {
             Assert.ThrowsAsync<BadRequestException>(async () =>
             {
-                var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
+                var repo = new Repository<Hierarchy, int>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
                 var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
                 var collection = new RestCollection<Hierarchy, int>(repo, new ObjectPatcher<Hierarchy>(_fixture.PatcherProvider, _fixture.ReflectionHelper), instanciator);
 
@@ -208,7 +208,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task BaseClass_Collection_on_hierarchy_works()
         {
-            var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
+            var repo = new Repository<Hierarchy, int>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
             var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
             var collection = new RestCollection<Hierarchy, int>(repo, new BaseClassPatcher<Hierarchy>(_fixture.PatcherProvider, _fixture.ReflectionHelper, new InheritanceConfiguration()), instanciator);
 

--- a/test/Rdd.Domain.Tests/DefaultFixture.cs
+++ b/test/Rdd.Domain.Tests/DefaultFixture.cs
@@ -18,7 +18,7 @@ namespace Rdd.Domain.Tests
         public IReflectionHelper ReflectionHelper => ServiceProvider.GetService<IReflectionHelper>();
         public IInstanciator<User> Instanciator { get; private set; }
         public InMemoryStorageService InMemoryStorage { get; private set; }
-        public IRepository<User> UsersRepo { get; private set; }
+        public IRepository<User, Guid> UsersRepo { get; private set; }
 
         public DefaultFixture()
         {
@@ -37,7 +37,7 @@ namespace Rdd.Domain.Tests
             RightsService = new OpenRightExpressionsHelper<User>();
             Instanciator = new DefaultInstanciator<User>();
             InMemoryStorage = new InMemoryStorageService();
-            UsersRepo = new Repository<User>(InMemoryStorage, RightsService);
+            UsersRepo = new Repository<User, Guid>(InMemoryStorage, RightsService);
         }
 
         public void Dispose() { }

--- a/test/Rdd.Domain.Tests/Models/OpenRepository.cs
+++ b/test/Rdd.Domain.Tests/Models/OpenRepository.cs
@@ -1,17 +1,19 @@
 ﻿using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Rights;
 using Rdd.Infra.Storage;
+using System;
 using System.Linq;
 
 namespace Rdd.Domain.Tests.Models
 {
-    public class OpenRepository<TEntity> : Repository<TEntity>
-        where TEntity : class
+    public class OpenRepository<TEntity, TKey> : Repository<TEntity, TKey>
+        where TEntity : class, IPrimaryKey<TKey>
+        where TKey : IEquatable<TKey>
     {
         public OpenRepository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightsService)
         : base(storageService, rightsService) { }
 
-        protected override IQueryable<TEntity> ApplyRights(IQueryable<TEntity> entities, Query<TEntity> query)
+        protected override IQueryable<TEntity> ApplyRights(IQueryable<TEntity> entities, IQuery<TEntity> query)
         {
             if (query.Verb == Helpers.HttpVerbs.Get)
             {

--- a/test/Rdd.Domain.Tests/Models/UsersCollection.cs
+++ b/test/Rdd.Domain.Tests/Models/UsersCollection.cs
@@ -7,7 +7,7 @@ namespace Rdd.Domain.Tests.Models
 {
     public class UsersCollection : RestCollection<User, Guid>
     {
-        public UsersCollection(IRepository<User> repository, IPatcherProvider patcherProvider, IInstanciator<User> instanciator)
+        public UsersCollection(IRepository<User, Guid> repository, IPatcherProvider patcherProvider, IInstanciator<User> instanciator)
             : base(repository, new ObjectPatcher<User>(patcherProvider, new ReflectionHelper()), instanciator) { }
     }
 }

--- a/test/Rdd.Domain.Tests/Models/UsersCollectionWithHardcodedGetById.cs
+++ b/test/Rdd.Domain.Tests/Models/UsersCollectionWithHardcodedGetById.cs
@@ -1,6 +1,7 @@
 ﻿using Rdd.Domain.Models;
 using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Patchers;
+using Rdd.Infra.Web.Models;
 using System;
 using System.Threading.Tasks;
 
@@ -8,10 +9,10 @@ namespace Rdd.Domain.Tests.Models
 {
     public class UsersCollectionWithHardcodedGetById : UsersCollection
     {
-        public UsersCollectionWithHardcodedGetById(IRepository<User> repository, IPatcherProvider patcherProvider, IInstanciator<User> instanciator)
+        public UsersCollectionWithHardcodedGetById(IRepository<User, Guid> repository, IPatcherProvider patcherProvider, IInstanciator<User> instanciator)
             : base(repository, patcherProvider, instanciator) { }
 
-        public override Task<User> GetByIdAsync(Guid id, Query<User> query)
+        public override Task<User> GetByIdAsync(Guid id, IQuery<User> query)
         {
             //Only for get, because PUT will always make a GetById( ) to retrieve the entity to update
             if (query.Verb == Helpers.HttpVerbs.Get)

--- a/test/Rdd.Domain.Tests/Models/UsersCollectionWithParameters.cs
+++ b/test/Rdd.Domain.Tests/Models/UsersCollectionWithParameters.cs
@@ -6,7 +6,7 @@ namespace Rdd.Domain.Tests.Models
 {
     public class UsersCollectionWithParameters : RestCollection<UserWithParameters, int>
     {
-        public UsersCollectionWithParameters(IRepository<UserWithParameters> repository, IPatcherProvider patcherProvider, IInstanciator<UserWithParameters> instanciator)
+        public UsersCollectionWithParameters(IRepository<UserWithParameters, int> repository, IPatcherProvider patcherProvider, IInstanciator<UserWithParameters> instanciator)
             : base(repository, new ObjectPatcher<UserWithParameters>(patcherProvider, new ReflectionHelper()), instanciator) { }
     }
 }

--- a/test/Rdd.Domain.Tests/QueryTests.cs
+++ b/test/Rdd.Domain.Tests/QueryTests.cs
@@ -1,6 +1,7 @@
 ﻿using Rdd.Domain.Helpers;
 using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Tests.Models;
+using Rdd.Infra.Web.Models;
 using Xunit;
 
 namespace Rdd.Domain.Tests

--- a/test/Rdd.Domain.Tests/RightExpressionsHelperTests.cs
+++ b/test/Rdd.Domain.Tests/RightExpressionsHelperTests.cs
@@ -1,5 +1,6 @@
 ﻿using Rdd.Domain.Rights;
 using Rdd.Domain.Tests.Models;
+using Rdd.Infra.Web.Models;
 using Xunit;
 
 namespace Rdd.Domain.Tests
@@ -9,10 +10,10 @@ namespace Rdd.Domain.Tests
         [Fact]
         public void RightExpressionsHelper()
         {
-            var filter = new OpenRightExpressionsHelper<User>().GetFilter(new Domain.Models.Querying.Query<User> { Verb = Helpers.HttpVerbs.Get });
+            var filter = new OpenRightExpressionsHelper<User>().GetFilter(new Query<User> { Verb = Helpers.HttpVerbs.Get });
             Assert.True(filter.Compile()(null));
 
-            filter = new ClosedRightExpressionsHelper<User>().GetFilter(new Domain.Models.Querying.Query<User> { Verb = Helpers.HttpVerbs.Get });
+            filter = new ClosedRightExpressionsHelper<User>().GetFilter(new Query<User> { Verb = Helpers.HttpVerbs.Get });
             Assert.False(filter.Compile()(null));
         }
     }

--- a/test/Rdd.Infra.Tests/CollectionTests.cs
+++ b/test/Rdd.Infra.Tests/CollectionTests.cs
@@ -2,6 +2,7 @@ using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Tests;
 using Rdd.Domain.Tests.Models;
 using Rdd.Infra.Storage;
+using Rdd.Infra.Web.Models;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/test/Rdd.Infra.Tests/UsersRepository.cs
+++ b/test/Rdd.Infra.Tests/UsersRepository.cs
@@ -2,16 +2,18 @@
 using Rdd.Domain.Rights;
 using Rdd.Domain.Tests.Models;
 using Rdd.Infra.Storage;
+using Rdd.Infra.Web.Models;
+using System;
 using System.Linq;
 
 namespace Rdd.Infra.Tests
 {
-    public class UsersRepository : OpenRepository<User>
+    public class UsersRepository : OpenRepository<User, Guid>
     {
         public UsersRepository(IStorageService storageService, IRightExpressionsHelper<User> rightsService)
         : base(storageService, rightsService) { }
 
-        protected override IQueryable<User> ApplyOrderBys(IQueryable<User> entities, Query<User> query)
+        protected override IQueryable<User> ApplyOrderBys(IQueryable<User> entities, IQuery<User> query)
         {
             if (!query.OrderBys.Any())
             {

--- a/test/Rdd.Web.Tests/BeforeAfterSaveChangesValidation.cs
+++ b/test/Rdd.Web.Tests/BeforeAfterSaveChangesValidation.cs
@@ -1,18 +1,18 @@
-﻿using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Rdd.Application;
 using Rdd.Domain.Json;
-using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Rights;
 using Rdd.Infra.Storage;
+using Rdd.Infra.Web.Models;
 using Rdd.Web.Helpers;
 using Rdd.Web.Querying;
 using Rdd.Web.Tests.Models;
 using Rdd.Web.Tests.ServerMock;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Rdd.Web.Tests
@@ -70,7 +70,7 @@ namespace Rdd.Web.Tests
             Assert.Equal(0, onSave.DeleteCount);
             Assert.Equal(4, onSave.CallsCount);
 
-            await app.DeleteByIdAsync(updated.Id); 
+            await app.DeleteByIdAsync(updated.Id, new Query<ExchangeRate>()); 
 
             Assert.Equal(2, onSave.AddCount);
             Assert.Equal(2, onSave.UpdateCount);

--- a/test/Rdd.Web.Tests/CollectionPropertiesTests.cs
+++ b/test/Rdd.Web.Tests/CollectionPropertiesTests.cs
@@ -4,6 +4,8 @@ using Rdd.Infra.Storage;
 using System.Linq;
 using Rdd.Domain.Models.Querying;
 using Xunit;
+using System;
+using Rdd.Infra.Web.Models;
 
 namespace Rdd.Web.Tests
 {
@@ -11,14 +13,14 @@ namespace Rdd.Web.Tests
     {
         private DefaultFixture _fixture;
         private InMemoryStorageService _storage;
-        private OpenRepository<User> _repo;
+        private OpenRepository<User, Guid> _repo;
         private UsersCollection _collection;
 
         public CollectionPropertiesTests(DefaultFixture fixture)
         {
             _fixture = fixture;
             _storage = new InMemoryStorageService();
-            _repo = new OpenRepository<User>(_storage, _fixture.RightsService);
+            _repo = new OpenRepository<User, Guid>(_storage, _fixture.RightsService);
             _collection = new UsersCollection(_repo, _fixture.PatcherProvider, _fixture.Instanciator);
         }
 

--- a/test/Rdd.Web.Tests/ExceptionIntegrationTest.cs
+++ b/test/Rdd.Web.Tests/ExceptionIntegrationTest.cs
@@ -1,16 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.TestHost;
+﻿using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Rdd.Domain;
 using Rdd.Domain.Exceptions;
-using Rdd.Domain.Models.Querying;
+using Rdd.Infra.Web.Models;
 using Rdd.Web.Helpers;
 using Rdd.Web.Tests.ServerMock;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Rdd.Web.Tests
@@ -45,7 +45,7 @@ namespace Rdd.Web.Tests
         [MemberData(nameof(ExceptionCases))]
         public async Task HttpCodeExceptionOption(Exception exception, HttpStatusCode expected)
         {
-            var repo = new Mock<IRepository<ExchangeRate2>>();
+            var repo = new Mock<IRepository<ExchangeRate2, int>>();
             repo.Setup(r => r.GetAsync(It.IsAny<Query<ExchangeRate2>>()))
                 .Throws(exception);
 

--- a/test/Rdd.Web.Tests/Models/UserWebController.cs
+++ b/test/Rdd.Web.Tests/Models/UserWebController.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Rdd.Application;
+using Rdd.Infra.Web.Models;
 using Rdd.Web.Controllers;
 using Rdd.Web.Querying;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Rdd.Domain.Models.Querying;
 
 namespace Rdd.Web.Tests.Models
 {

--- a/test/Rdd.Web.Tests/Services/RddBuilderTests.cs
+++ b/test/Rdd.Web.Tests/Services/RddBuilderTests.cs
@@ -12,6 +12,7 @@ using Rdd.Domain.Patchers;
 using Rdd.Domain.Rights;
 using Rdd.Domain.Tests.Models;
 using Rdd.Infra.Storage;
+using Rdd.Infra.Web.Models;
 using Rdd.Web.Helpers;
 using Rdd.Web.Querying;
 using Rdd.Web.Serialization.Providers;
@@ -87,13 +88,15 @@ namespace Rdd.Web.Tests.Services
             Assert.Empty(configs);
         }
 
-        class RepoPipo : IRepository<Hierarchy>
+        class RepoPipo : IRepository<Hierarchy, int>
         {
             public void Add(Hierarchy entity) => throw new NotImplementedException();
             public void AddRange(IEnumerable<Hierarchy> entities) => throw new NotImplementedException();
-            public Task<int> CountAsync(Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task<int> CountAsync(IQuery<Hierarchy> query) => throw new NotImplementedException();
             public void DiscardChanges(Hierarchy entity) => throw new NotImplementedException();
-            public Task<IEnumerable<Hierarchy>> GetAsync(Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task<ISelection<Hierarchy>> GetAsync(IQuery<Hierarchy> query) => throw new NotImplementedException();
+            public Task<Hierarchy> GetByIdAsync(int id, IQuery<Hierarchy> query) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> GetByIdsAsync(IEnumerable<int> ids, IQuery<Hierarchy> query) => throw new NotImplementedException();
             public Task<IEnumerable<Hierarchy>> PrepareAsync(IEnumerable<Hierarchy> entities, Query<Hierarchy> query) => throw new NotImplementedException();
             public void Remove(Hierarchy entity) => throw new NotImplementedException();
         }
@@ -102,12 +105,12 @@ namespace Rdd.Web.Tests.Services
         public void TestReadOnlyRepoRegister()
         {
             var services = new ServiceCollection();
-            new RddBuilder(services).AddReadOnlyRepository<RepoPipo, Hierarchy>();
+            new RddBuilder(services).AddReadOnlyRepository<RepoPipo, Hierarchy, int>();
             var provider = services.BuildServiceProvider();
 
-            Assert.Null(provider.GetService<IRepository<Hierarchy>>());
+            Assert.Null(provider.GetService<IRepository<Hierarchy, int>>());
 
-            var repo2 = provider.GetRequiredService<IReadOnlyRepository<Hierarchy>>();
+            var repo2 = provider.GetRequiredService<IReadOnlyRepository<Hierarchy, int>>();
             var repo3 = provider.GetRequiredService<RepoPipo>();
 
             Assert.Equal(repo2, repo3);
@@ -117,11 +120,11 @@ namespace Rdd.Web.Tests.Services
         public void TestRepoRegister()
         {
             var services = new ServiceCollection();
-            new RddBuilder(services).AddRepository<RepoPipo, Hierarchy>();
+            new RddBuilder(services).AddRepository<RepoPipo, Hierarchy, int>();
             var provider = services.BuildServiceProvider();
 
-            var repo = provider.GetRequiredService<IRepository<Hierarchy>>();
-            var repo2 = provider.GetRequiredService<IReadOnlyRepository<Hierarchy>>();
+            var repo = provider.GetRequiredService<IRepository<Hierarchy, int>>();
+            var repo2 = provider.GetRequiredService<IReadOnlyRepository<Hierarchy, int>>();
             var repo3 = provider.GetRequiredService<RepoPipo>();
 
             Assert.Equal(repo, repo2);
@@ -131,19 +134,17 @@ namespace Rdd.Web.Tests.Services
 
         class CollectionPipo : IRestCollection<Hierarchy, int>
         {
-            public Task<bool> AnyAsync(Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task<Hierarchy> CreateAsync(ICandidate<Hierarchy, int> candidate, IQuery<Hierarchy> query = null) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> CreateAsync(IEnumerable<ICandidate<Hierarchy, int>> candidates, IQuery<Hierarchy> query = null) => throw new NotImplementedException();
 
-            public Task<Hierarchy> CreateAsync(ICandidate<Hierarchy, int> candidate, Query<Hierarchy> query = null) => throw new NotImplementedException();
-            public Task<IEnumerable<Hierarchy>> CreateAsync(IEnumerable<ICandidate<Hierarchy, int>> candidates, Query<Hierarchy> query = null) => throw new NotImplementedException();
+            public Task DeleteByIdAsync(int id, IQuery<Hierarchy> query = null) => throw new NotImplementedException();
+            public Task DeleteByIdsAsync(IEnumerable<int> ids, IQuery<Hierarchy> query = null) => throw new NotImplementedException();
 
-            public Task DeleteByIdAsync(int id) => throw new NotImplementedException();
-            public Task DeleteByIdsAsync(IEnumerable<int> ids) => throw new NotImplementedException();
+            public Task<ISelection<Hierarchy>> GetAsync(IQuery<Hierarchy> query) => throw new NotImplementedException();
+            public Task<Hierarchy> GetByIdAsync(int id, IQuery<Hierarchy> query) => throw new NotImplementedException();
 
-            public Task<ISelection<Hierarchy>> GetAsync(Query<Hierarchy> query) => throw new NotImplementedException();
-            public Task<Hierarchy> GetByIdAsync(int id, Query<Hierarchy> query) => throw new NotImplementedException();
-
-            public Task<Hierarchy> UpdateByIdAsync(int id, ICandidate<Hierarchy, int> candidate, Query<Hierarchy> query = null) => throw new NotImplementedException();
-            public Task<IEnumerable<Hierarchy>> UpdateByIdsAsync(IDictionary<int, ICandidate<Hierarchy, int>> candidatesByIds, Query<Hierarchy> query = null) => throw new NotImplementedException();
+            public Task<Hierarchy> UpdateByIdAsync(int id, ICandidate<Hierarchy, int> candidate, IQuery<Hierarchy> query = null) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> UpdateByIdsAsync(IDictionary<int, ICandidate<Hierarchy, int>> candidatesByIds, IQuery<Hierarchy> query = null) => throw new NotImplementedException();
         }
 
         [Fact]
@@ -179,14 +180,14 @@ namespace Rdd.Web.Tests.Services
 
         class ControllerPipo : IAppController<Hierarchy, int>
         {
-            public Task<Hierarchy> CreateAsync(ICandidate<Hierarchy, int> candidate, Query<Hierarchy> query) => throw new NotImplementedException();
-            public Task<IEnumerable<Hierarchy>> CreateAsync(IEnumerable<ICandidate<Hierarchy, int>> candidates, Query<Hierarchy> query) => throw new NotImplementedException();
-            public Task DeleteByIdAsync(int id) => throw new NotImplementedException();
-            public Task DeleteByIdsAsync(IEnumerable<int> ids) => throw new NotImplementedException();
-            public Task<ISelection<Hierarchy>> GetAsync(Query<Hierarchy> query) => throw new NotImplementedException();
-            public Task<Hierarchy> GetByIdAsync(int id, Query<Hierarchy> query) => throw new NotImplementedException();
-            public Task<Hierarchy> UpdateByIdAsync(int id, ICandidate<Hierarchy, int> candidate, Query<Hierarchy> query) => throw new NotImplementedException();
-            public Task<IEnumerable<Hierarchy>> UpdateByIdsAsync(IDictionary<int, ICandidate<Hierarchy, int>> candidatesByIds, Query<Hierarchy> query) => throw new NotImplementedException();
+            public Task<Hierarchy> CreateAsync(ICandidate<Hierarchy, int> candidate, IQuery<Hierarchy> query) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> CreateAsync(IEnumerable<ICandidate<Hierarchy, int>> candidates, IQuery<Hierarchy> query) => throw new NotImplementedException();
+            public Task DeleteByIdAsync(int id, IQuery<Hierarchy> query = null) => throw new NotImplementedException();
+            public Task DeleteByIdsAsync(IEnumerable<int> ids, IQuery<Hierarchy> query = null) => throw new NotImplementedException();
+            public Task<ISelection<Hierarchy>> GetAsync(IQuery<Hierarchy> query) => throw new NotImplementedException();
+            public Task<Hierarchy> GetByIdAsync(int id, IQuery<Hierarchy> query) => throw new NotImplementedException();
+            public Task<Hierarchy> UpdateByIdAsync(int id, ICandidate<Hierarchy, int> candidate, IQuery<Hierarchy> query) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> UpdateByIdsAsync(IDictionary<int, ICandidate<Hierarchy, int>> candidatesByIds, IQuery<Hierarchy> query) => throw new NotImplementedException();
         }
 
         [Fact]

--- a/test/Rdd.Web.Tests/Services/ServicesCollectionTests.cs
+++ b/test/Rdd.Web.Tests/Services/ServicesCollectionTests.cs
@@ -6,17 +6,11 @@ using Rdd.Domain.Json;
 using Rdd.Domain.Models;
 using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Patchers;
-using Rdd.Domain.Rights;
-using Rdd.Domain.Tests.Models;
 using Rdd.Infra.Storage;
 using Rdd.Web.Helpers;
 using Rdd.Web.Querying;
 using Rdd.Web.Serialization.Providers;
 using Rdd.Web.Tests.ServerMock;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Rdd.Web.Tests.Services
@@ -43,8 +37,8 @@ namespace Rdd.Web.Tests.Services
 
             Assert.NotNull(provider.GetRequiredService<ISerializerProvider>());
 
-            Assert.NotNull(provider.GetRequiredService<IReadOnlyRepository<ExchangeRate>>());
-            Assert.NotNull(provider.GetRequiredService<IRepository<ExchangeRate>>());
+            Assert.NotNull(provider.GetRequiredService<IReadOnlyRepository<ExchangeRate, int>>());
+            Assert.NotNull(provider.GetRequiredService<IRepository<ExchangeRate, int>>());
             Assert.NotNull(provider.GetRequiredService<IPatcher<ExchangeRate>>());
             Assert.NotNull(provider.GetRequiredService<IInstanciator<ExchangeRate>>());
             Assert.NotNull(provider.GetRequiredService<IReadOnlyRestCollection<ExchangeRate, int>>());

--- a/test/Rdd.Web.Tests/ValidationTests.cs
+++ b/test/Rdd.Web.Tests/ValidationTests.cs
@@ -1,16 +1,15 @@
-﻿using System;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Rdd.Domain;
-using Rdd.Domain.Json;
 using Rdd.Domain.Models;
-using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Patchers;
 using Rdd.Domain.Rights;
+using Rdd.Infra.Web.Models;
 using Rdd.Web.Helpers;
 using Rdd.Web.Querying;
 using Rdd.Web.Tests.ServerMock;
+using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Rdd.Web.Tests
@@ -67,7 +66,7 @@ namespace Rdd.Web.Tests
 
         public class ValidationFailCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
-            public ValidationFailCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
+            public ValidationFailCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
                 : base(repository, patcher, instanciator) { }
 
             protected override Task<bool> ValidateEntityAsync(TEntity entity) => Task.FromResult(false);
@@ -75,7 +74,7 @@ namespace Rdd.Web.Tests
 
         public class ValidationOkCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
-            public ValidationOkCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
+            public ValidationOkCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
                 : base(repository, patcher, instanciator) { }
 
             protected override Task<bool> ValidateEntityAsync(TEntity entity) => Task.FromResult(true);
@@ -83,7 +82,7 @@ namespace Rdd.Web.Tests
 
         public class ValidationThrowCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
-            public ValidationThrowCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
+            public ValidationThrowCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
                 : base(repository, patcher, instanciator) { }
 
             protected override Task<bool> ValidateEntityAsync(TEntity entity) => throw new NotImplementedException();
@@ -91,7 +90,7 @@ namespace Rdd.Web.Tests
 
         public class ValidationThrowAsyncCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
-            public ValidationThrowAsyncCollection(IRepository<TEntity> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
+            public ValidationThrowAsyncCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
                 : base(repository, patcher, instanciator) { }
 
             protected override async Task<bool> ValidateEntityAsync(TEntity entity)

--- a/test/Rdd.Web.Tests/WebControllerTests.cs
+++ b/test/Rdd.Web.Tests/WebControllerTests.cs
@@ -16,7 +16,7 @@ namespace Rdd.Web.Tests
         {
             using (var storage = new InMemoryStorageService())
             {
-                var repository = new Repository<IUser>(storage, null);
+                var repository = new Repository<IUser, int>(storage, null);
                 var collection = new ReadOnlyRestCollection<IUser, int>(repository);
                 var appController = new ReadOnlyAppController<IUser, int>(collection);
 

--- a/test/Rdd.Web.Tests/WebPagingTests.cs
+++ b/test/Rdd.Web.Tests/WebPagingTests.cs
@@ -4,6 +4,8 @@ using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Tests;
 using Rdd.Domain.Tests.Models;
 using Rdd.Infra.Storage;
+using Rdd.Infra.Web.Models;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,14 +17,14 @@ namespace Rdd.Web.Tests
     {
         private DefaultFixture _fixture;
         private InMemoryStorageService _storage;
-        private OpenRepository<User> _repo;
+        private OpenRepository<User, Guid> _repo;
         private UsersCollection _collection;
 
         public WebPaginggTests(DefaultFixture fixture)
         {
             _fixture = fixture;
             _storage = new InMemoryStorageService();
-            _repo = new OpenRepository<User>(_storage, _fixture.RightsService);
+            _repo = new OpenRepository<User, Guid>(_storage, _fixture.RightsService);
             _collection = new UsersCollection(_repo, _fixture.PatcherProvider, _fixture.Instanciator);
         }
 


### PR DESCRIPTION
- Query part dans l'Infra car les Query devraient uniquemnt être créées depuis la couche web (via l'appel web entrant) ou depuis un repo dans l'infra. Tout autre appel métier devrait être explicite, càd via une méthode explicite dans l'AppController et/ou dans la Collection qui appelle alors une méthode explicite du Repo qui lui peut alors créer une Query et repasser par son GetAsync()
- J'ai viré AnyAsync() mais je peux le remettre...
- J'ai déplacé la logique du GetAsync() de la Collection dans le Repo, car pour moi ça n'est pas du métier mais du technique

NB : Concernant ISelection, j'ai une piste que je vais explorer dans une autre PR pour le virer, ça fera plaisir à Raph ;)