### PR TITLE
MOD : instanciation des TEntity

### DIFF
--- a/src/RDD.Domain/Models/IInstantiator.cs
+++ b/src/RDD.Domain/Models/IInstantiator.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Rdd.Domain.Models
+{
+    public interface IInstantiator<TEntity>
+    {
+        Task<TEntity> InstantiateAsync(ICandidate<TEntity> candidate);
+    }
+}

--- a/src/Rdd.Domain/Models/BaseClassInstanciator.cs
+++ b/src/Rdd.Domain/Models/BaseClassInstanciator.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Rdd.Domain.Models
 {
-    public class BaseClassInstanciator<TEntity> : IInstanciator<TEntity>
+    public class BaseClassInstanciator<TEntity> : IInstantiator<TEntity>
         where TEntity : class
     {
         private readonly IInheritanceConfiguration<TEntity> _configuration;
@@ -12,14 +13,14 @@ namespace Rdd.Domain.Models
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
 
-        public TEntity InstanciateNew(ICandidate<TEntity> candidate)
+        public Task<TEntity> InstantiateAsync(ICandidate<TEntity> candidate)
         {
             if (candidate.JsonValue.HasJsonValue(_configuration.Discriminator))
             {
                 var value = candidate.JsonValue.GetJsonValue(_configuration.Discriminator);
                 if (_configuration.Mappings.ContainsKey(value))
                 {
-                    return Activator.CreateInstance(_configuration.Mappings[value]) as TEntity;
+                    return Task.FromResult(Activator.CreateInstance(_configuration.Mappings[value]) as TEntity);
                 }
             }
 

--- a/src/Rdd.Domain/Models/DefaultInstanciator.cs
+++ b/src/Rdd.Domain/Models/DefaultInstanciator.cs
@@ -1,8 +1,10 @@
-﻿namespace Rdd.Domain.Models
+﻿using System.Threading.Tasks;
+
+namespace Rdd.Domain.Models
 {
-    public class DefaultInstanciator<TEntity> : IInstanciator<TEntity>
+    public class DefaultInstanciator<TEntity> : IInstantiator<TEntity>
         where TEntity : class, new()
     {
-        public TEntity InstanciateNew(ICandidate<TEntity> candidate) => new TEntity();
+        public Task<TEntity> InstantiateAsync(ICandidate<TEntity> candidate) => Task.FromResult(new TEntity());
     }
 }

--- a/src/Rdd.Domain/Models/IInstanciator.cs
+++ b/src/Rdd.Domain/Models/IInstanciator.cs
@@ -1,7 +1,0 @@
-﻿namespace Rdd.Domain.Models
-{
-    public interface IInstanciator<TEntity>
-    {
-        TEntity InstanciateNew(ICandidate<TEntity> candidate);
-    }
-}

--- a/src/Rdd.Domain/Models/RestCollection.cs
+++ b/src/Rdd.Domain/Models/RestCollection.cs
@@ -15,19 +15,21 @@ namespace Rdd.Domain.Models
         protected new IRepository<TEntity, TKey> Repository { get; set; }
         protected IPatcher<TEntity> Patcher { get; set; }
 
-        protected IInstanciator<TEntity> Instanciator { get; set; }
-
-        public RestCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator)
+        public RestCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher)
             : base(repository)
         {
             Patcher = patcher;
             Repository = repository;
-            Instanciator = instanciator;
+        }
+
+        public virtual Task<TEntity> InstantiateEntityAsync(ICandidate<TEntity, TKey> candidate)
+        {
+            throw new NotImplementedException(@"You have to override InstanciateEntity. You could implement a ""return new TEntity();"" or inject an IInstantiator<TEntity> into your Collection");
         }
 
         public virtual async Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, IQuery<TEntity> query = null)
         {
-            TEntity entity = Instanciator.InstanciateNew(candidate);
+            TEntity entity = await InstantiateEntityAsync(candidate);
 
             entity = Patcher.Patch(entity, candidate.JsonValue);
 
@@ -48,7 +50,7 @@ namespace Rdd.Domain.Models
 
             foreach (var candidate in candidates)
             {
-                TEntity entity = Instanciator.InstanciateNew(candidate);
+                TEntity entity = await InstantiateEntityAsync(candidate);
 
                 entity = Patcher.Patch(entity, candidate.JsonValue);
 

--- a/src/Rdd.Web/Helpers/RddBuilderExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Rdd.Web.Helpers
             services.AddSingleton<IInheritanceConfiguration<TEntity>>(s => config);
 
             services.TryAddSingleton<IPatcher<TEntity>, BaseClassPatcher<TEntity>>();
-            services.TryAddSingleton<IInstanciator<TEntity>, BaseClassInstanciator<TEntity>>();
+            services.TryAddSingleton<IInstantiator<TEntity>, BaseClassInstanciator<TEntity>>();
 
             rddBuilder.AddJsonConverter(new BaseClassJsonConverter<TEntity>(config));
 

--- a/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ namespace Rdd.Web.Helpers
         {
             services.AddOptions<RddOptions>();
 
-            services.TryAddSingleton(typeof(IInstanciator<>), typeof(DefaultInstanciator<>));
+            services.TryAddSingleton(typeof(IInstantiator<>), typeof(DefaultInstanciator<>));
             services.TryAddSingleton<IPatcherProvider, PatcherProvider>();
             services.TryAddSingleton(typeof(IPatcher<>), typeof(ObjectPatcher<>));
             services.TryAddSingleton<EnumerablePatcher>();

--- a/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
+++ b/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
@@ -83,14 +83,14 @@ namespace Rdd.Domain.Tests
             await users.CreateAsync(candidate, query);
         }
 
-        private class InstanciatorImplementation : IInstanciator<UserWithParameters>
+        private class InstanciatorImplementation : IInstantiator<UserWithParameters>
         {
-            public UserWithParameters InstanciateNew(ICandidate<UserWithParameters> candidate)
+            public Task<UserWithParameters> InstantiateAsync(ICandidate<UserWithParameters> candidate)
             {
                 var id = candidate.Value.Id;
                 var name = candidate.Value.Name;
 
-                return new UserWithParameters(id, name);
+                return Task.FromResult(new UserWithParameters(id, name));
             }
         }
 
@@ -163,7 +163,7 @@ namespace Rdd.Domain.Tests
             _fixture.InMemoryStorage.Add(user);
             await _fixture.InMemoryStorage.SaveChangesAsync();
 
-            var users = new RestCollection<User, Guid>(_fixture.UsersRepo, new OverrideObjectPatcher<User>(_fixture.PatcherProvider), _fixture.Instanciator);
+            var users = new UsersCollection(_fixture.UsersRepo, new OverrideObjectPatcher<User>(_fixture.PatcherProvider), _fixture.Instanciator);
             var query = new Query<User>();
             query.Options.CheckRights = false;
 
@@ -198,7 +198,7 @@ namespace Rdd.Domain.Tests
             {
                 var repo = new Repository<Hierarchy, int>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
                 var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
-                var collection = new RestCollection<Hierarchy, int>(repo, new ObjectPatcher<Hierarchy>(_fixture.PatcherProvider, _fixture.ReflectionHelper), instanciator);
+                var collection = new HierarchiesCollection(repo, new ObjectPatcher<Hierarchy>(_fixture.PatcherProvider, _fixture.ReflectionHelper), instanciator);
 
                 var candidate = _parser.Parse<Hierarchy, int>(@"{ ""type"":""super"", ""superProperty"": ""lol"" }");
                 await collection.CreateAsync(candidate);
@@ -210,7 +210,7 @@ namespace Rdd.Domain.Tests
         {
             var repo = new Repository<Hierarchy, int>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
             var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
-            var collection = new RestCollection<Hierarchy, int>(repo, new BaseClassPatcher<Hierarchy>(_fixture.PatcherProvider, _fixture.ReflectionHelper, new InheritanceConfiguration()), instanciator);
+            var collection = new HierarchiesCollection(repo, new BaseClassPatcher<Hierarchy>(_fixture.PatcherProvider, _fixture.ReflectionHelper, new InheritanceConfiguration()), instanciator);
 
             var candidate = _parser.Parse<Hierarchy, int>(@"{ ""type"":""super"", ""superProperty"": ""lol"" }");
             await collection.CreateAsync(candidate);

--- a/test/Rdd.Domain.Tests/DefaultFixture.cs
+++ b/test/Rdd.Domain.Tests/DefaultFixture.cs
@@ -16,7 +16,7 @@ namespace Rdd.Domain.Tests
         public IRightExpressionsHelper<User> RightsService { get; private set; }
         public IPatcherProvider PatcherProvider => ServiceProvider.GetService<IPatcherProvider>();
         public IReflectionHelper ReflectionHelper => ServiceProvider.GetService<IReflectionHelper>();
-        public IInstanciator<User> Instanciator { get; private set; }
+        public IInstantiator<User> Instanciator { get; private set; }
         public InMemoryStorageService InMemoryStorage { get; private set; }
         public IRepository<User, Guid> UsersRepo { get; private set; }
 

--- a/test/Rdd.Domain.Tests/Models/HierarchiesCollection.cs
+++ b/test/Rdd.Domain.Tests/Models/HierarchiesCollection.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using Rdd.Domain.Helpers.Reflection;
+using Rdd.Domain.Models;
+using Rdd.Domain.Patchers;
+
+namespace Rdd.Domain.Tests.Models
+{
+    public class HierarchiesCollection : RestCollection<Hierarchy, int>
+    {
+        private readonly IInstantiator<Hierarchy> _instanciator;
+
+        public HierarchiesCollection(IRepository<Hierarchy, int> repository, IPatcher<Hierarchy> patcher, IInstantiator<Hierarchy> instanciator)
+            : base(repository, patcher)
+        {
+            _instanciator = instanciator;
+        }
+
+        public HierarchiesCollection(IRepository<Hierarchy, int> repository, IPatcherProvider patcherProvider, IInstantiator<Hierarchy> instanciator)
+            : this(repository, new ObjectPatcher<Hierarchy>(patcherProvider, new ReflectionHelper()), instanciator) { }
+
+        public override Task<Hierarchy> InstantiateEntityAsync(ICandidate<Hierarchy, int> candidate)
+        {
+            return _instanciator.InstantiateAsync(candidate);
+        }
+    }
+}

--- a/test/Rdd.Domain.Tests/Models/UsersCollection.cs
+++ b/test/Rdd.Domain.Tests/Models/UsersCollection.cs
@@ -2,12 +2,26 @@
 using Rdd.Domain.Models;
 using Rdd.Domain.Patchers;
 using System;
+using System.Threading.Tasks;
 
 namespace Rdd.Domain.Tests.Models
 {
     public class UsersCollection : RestCollection<User, Guid>
     {
-        public UsersCollection(IRepository<User, Guid> repository, IPatcherProvider patcherProvider, IInstanciator<User> instanciator)
-            : base(repository, new ObjectPatcher<User>(patcherProvider, new ReflectionHelper()), instanciator) { }
+        private readonly IInstantiator<User> _instanciator;
+
+        public UsersCollection(IRepository<User, Guid> repository, IPatcher<User> patcher, IInstantiator<User> instanciator)
+            : base(repository, patcher)
+        {
+            _instanciator = instanciator;
+        }
+
+        public UsersCollection(IRepository<User, Guid> repository, IPatcherProvider patcherProvider, IInstantiator<User> instanciator)
+            : this(repository, new ObjectPatcher<User>(patcherProvider, new ReflectionHelper()), instanciator) { }
+
+        public override Task<User> InstantiateEntityAsync(ICandidate<User, Guid> candidate)
+        {
+            return _instanciator.InstantiateAsync(candidate);
+        }
     }
 }

--- a/test/Rdd.Domain.Tests/Models/UsersCollectionWithHardcodedGetById.cs
+++ b/test/Rdd.Domain.Tests/Models/UsersCollectionWithHardcodedGetById.cs
@@ -9,7 +9,7 @@ namespace Rdd.Domain.Tests.Models
 {
     public class UsersCollectionWithHardcodedGetById : UsersCollection
     {
-        public UsersCollectionWithHardcodedGetById(IRepository<User, Guid> repository, IPatcherProvider patcherProvider, IInstanciator<User> instanciator)
+        public UsersCollectionWithHardcodedGetById(IRepository<User, Guid> repository, IPatcherProvider patcherProvider, IInstantiator<User> instanciator)
             : base(repository, patcherProvider, instanciator) { }
 
         public override Task<User> GetByIdAsync(Guid id, IQuery<User> query)

--- a/test/Rdd.Domain.Tests/Models/UsersCollectionWithParameters.cs
+++ b/test/Rdd.Domain.Tests/Models/UsersCollectionWithParameters.cs
@@ -1,4 +1,5 @@
-﻿using Rdd.Domain.Helpers.Reflection;
+﻿using System.Threading.Tasks;
+using Rdd.Domain.Helpers.Reflection;
 using Rdd.Domain.Models;
 using Rdd.Domain.Patchers;
 
@@ -6,7 +7,17 @@ namespace Rdd.Domain.Tests.Models
 {
     public class UsersCollectionWithParameters : RestCollection<UserWithParameters, int>
     {
-        public UsersCollectionWithParameters(IRepository<UserWithParameters, int> repository, IPatcherProvider patcherProvider, IInstanciator<UserWithParameters> instanciator)
-            : base(repository, new ObjectPatcher<UserWithParameters>(patcherProvider, new ReflectionHelper()), instanciator) { }
+        private readonly IInstantiator<UserWithParameters> _instanciator;
+
+        public UsersCollectionWithParameters(IRepository<UserWithParameters, int> repository, IPatcherProvider patcherProvider, IInstantiator<UserWithParameters> instanciator)
+            : base(repository, new ObjectPatcher<UserWithParameters>(patcherProvider, new ReflectionHelper()))
+        {
+            _instanciator = instanciator;
+        }
+
+        public override Task<UserWithParameters> InstantiateEntityAsync(ICandidate<UserWithParameters, int> candidate)
+        {
+            return _instanciator.InstantiateAsync(candidate);
+        }
     }
 }

--- a/test/Rdd.Web.Tests/BeforeAfterSaveChangesValidation.cs
+++ b/test/Rdd.Web.Tests/BeforeAfterSaveChangesValidation.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Rdd.Application;
+using Rdd.Domain;
 using Rdd.Domain.Json;
 using Rdd.Domain.Rights;
 using Rdd.Infra.Storage;
@@ -39,6 +40,7 @@ namespace Rdd.Web.Tests
 
             services.AddScoped<OnExchangeRateSave>();
             services.AddScoped<OnAnotherUserSave>();
+            services.AddScoped<IRestCollection<ExchangeRate, int>, ExchangeRatesCollection>();
             services.AddScoped<ISaveEventProcessor>(s => s.GetRequiredService<OnExchangeRateSave>());
             services.AddScoped<ISaveEventProcessor>(s => s.GetRequiredService<OnAnotherUserSave>());
 

--- a/test/Rdd.Web.Tests/ServerMock/ExchangeRatesCollection.cs
+++ b/test/Rdd.Web.Tests/ServerMock/ExchangeRatesCollection.cs
@@ -1,0 +1,18 @@
+﻿using Rdd.Domain;
+using Rdd.Domain.Models;
+using Rdd.Domain.Patchers;
+using System.Threading.Tasks;
+
+namespace Rdd.Web.Tests.ServerMock
+{
+    public class ExchangeRatesCollection : RestCollection<ExchangeRate, int>
+    {
+        public ExchangeRatesCollection(IRepository<ExchangeRate, int> repository, IPatcher<ExchangeRate> patcher)
+            : base(repository, patcher) { }
+
+        public override Task<ExchangeRate> InstantiateEntityAsync(ICandidate<ExchangeRate, int> candidate)
+        {
+            return Task.FromResult(new ExchangeRate());
+        }
+    }
+}

--- a/test/Rdd.Web.Tests/ServerMock/Startup.cs
+++ b/test/Rdd.Web.Tests/ServerMock/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Rdd.Domain;
 using Rdd.Domain.Rights;
 using Rdd.Web.Helpers;
 
@@ -31,6 +32,7 @@ namespace Rdd.Web.Tests.ServerMock
                     rdd.PagingLimit = 10;
                     rdd.PagingMaximumLimit = 4242;
                 })
+                .AddRestCollection<ExchangeRatesCollection, ExchangeRate, int>()
                 .WithDefaultRights(RightDefaultMode.Open);
 
             services.AddMvc();

--- a/test/Rdd.Web.Tests/Services/RddBuilderTests.cs
+++ b/test/Rdd.Web.Tests/Services/RddBuilderTests.cs
@@ -77,7 +77,7 @@ namespace Rdd.Web.Tests.Services
             provider.GetRequiredService<IInheritanceConfiguration<Hierarchy2>>();
 
             Assert.IsType<BaseClassPatcher<Hierarchy>>(provider.GetRequiredService<IPatcher<Hierarchy>>());
-            Assert.IsType<BaseClassInstanciator<Hierarchy>>(provider.GetRequiredService<IInstanciator<Hierarchy>>());
+            Assert.IsType<BaseClassInstanciator<Hierarchy>>(provider.GetRequiredService<IInstantiator<Hierarchy>>());
         }
 
         [Fact]

--- a/test/Rdd.Web.Tests/Services/ServicesCollectionTests.cs
+++ b/test/Rdd.Web.Tests/Services/ServicesCollectionTests.cs
@@ -40,7 +40,7 @@ namespace Rdd.Web.Tests.Services
             Assert.NotNull(provider.GetRequiredService<IReadOnlyRepository<ExchangeRate, int>>());
             Assert.NotNull(provider.GetRequiredService<IRepository<ExchangeRate, int>>());
             Assert.NotNull(provider.GetRequiredService<IPatcher<ExchangeRate>>());
-            Assert.NotNull(provider.GetRequiredService<IInstanciator<ExchangeRate>>());
+            Assert.NotNull(provider.GetRequiredService<IInstantiator<ExchangeRate>>());
             Assert.NotNull(provider.GetRequiredService<IReadOnlyRestCollection<ExchangeRate, int>>());
             Assert.NotNull(provider.GetRequiredService<IRestCollection<ExchangeRate, int>>());
             Assert.NotNull(provider.GetRequiredService<IReadOnlyAppController<ExchangeRate, int>>());

--- a/test/Rdd.Web.Tests/ValidationTests.cs
+++ b/test/Rdd.Web.Tests/ValidationTests.cs
@@ -66,32 +66,32 @@ namespace Rdd.Web.Tests
 
         public class ValidationFailCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
-            public ValidationFailCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
-                : base(repository, patcher, instanciator) { }
+            public ValidationFailCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher) 
+                : base(repository, patcher) { }
 
             protected override Task<bool> ValidateEntityAsync(TEntity entity) => Task.FromResult(false);
         }
 
         public class ValidationOkCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
-            public ValidationOkCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
-                : base(repository, patcher, instanciator) { }
+            public ValidationOkCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher) 
+                : base(repository, patcher) { }
 
             protected override Task<bool> ValidateEntityAsync(TEntity entity) => Task.FromResult(true);
         }
 
         public class ValidationThrowCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
-            public ValidationThrowCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
-                : base(repository, patcher, instanciator) { }
+            public ValidationThrowCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher) 
+                : base(repository, patcher) { }
 
             protected override Task<bool> ValidateEntityAsync(TEntity entity) => throw new NotImplementedException();
         }
 
         public class ValidationThrowAsyncCollection<TEntity, TKey> : RestCollection<TEntity, TKey> where TEntity : class, IEntityBase<TKey> where TKey : IEquatable<TKey>
         {
-            public ValidationThrowAsyncCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher, IInstanciator<TEntity> instanciator) 
-                : base(repository, patcher, instanciator) { }
+            public ValidationThrowAsyncCollection(IRepository<TEntity, TKey> repository, IPatcher<TEntity> patcher) 
+                : base(repository, patcher) { }
 
             protected override async Task<bool> ValidateEntityAsync(TEntity entity)
             {


### PR DESCRIPTION
- je vire la contrainte sur les Collections de devoir s'injecter un IInstanciator dans les cas simples (=la plupart du temps) où on veut faire un new T()
- l'exception par défaut va forcer les gens à créer des Collections explicites, c'est plutôt sain quand on est en écriture, ça veut dire qu'on ne laisse pas l'injection générique créer des objets en base sans aucun contrôle !
- les tests permettent de voir plusieurs scénarios : soit un instantiator explicite injecté, soit un override simple de la méthode

ENH : passage en Async sur toute la chaîne
FIX : coquille sur l'orhographe de IInstantiator (t et pas c)

PS : PR vers la PR #267 donc à ne pas merger (je rebaserai sur master si vous approuvez)