### PR TITLE
FIX : filtre sur les mailsaddresses

### DIFF
--- a/src/Rdd.Infra/Helpers/WebFilterConverter.cs
+++ b/src/Rdd.Infra/Helpers/WebFilterConverter.cs
@@ -8,12 +8,16 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net.Mail;
 
 namespace Rdd.Infra.Helpers
 {
     public class WebFilterConverter<TEntity> : IWebFilterConverter<TEntity>
     {
         private const int EF_EXPRESSION_TREE_MAX_DEPTH = 1000;
+
+        private static readonly HashSet<Type> KnownTypesEvaluatedClientSideWithHashCode
+            = new HashSet<Type> { typeof(MailAddress) };
 
         public Expression<Func<TEntity, bool>> ToExpression(IEnumerable<WebFilter<TEntity>> filters) => filters.Select(ToExpression).AndAggregation();
 
@@ -60,7 +64,7 @@ namespace Rdd.Infra.Helpers
         public Expression<Func<TEntity, bool>> Equals(IExpression field, IList values) => BuildLambda(Contains, field, values);
         protected virtual Expression Contains(Expression leftExpression, IList values)
         {
-            if (values.Count == 1)
+            if (values.Count == 1 && !KnownTypesEvaluatedClientSideWithHashCode.Contains(leftExpression.Type))
             {
                 return Expression.Equal(leftExpression, Expression.Constant(values[0]));
             }
@@ -73,7 +77,7 @@ namespace Rdd.Infra.Helpers
         public Expression<Func<TEntity, bool>> NotEqual(IExpression field, IList values) => BuildLambda(NotEqual, field, values);
         protected virtual Expression NotEqual(Expression leftExpression, IList values)
         {
-            if (values.Count == 1)
+            if (values.Count == 1 && !KnownTypesEvaluatedClientSideWithHashCode.Contains(leftExpression.Type))
             {
                 return Expression.NotEqual(leftExpression, Expression.Constant(values[0]));
             }

--- a/src/Rdd.Infra/Helpers/WebFilterConverter.cs
+++ b/src/Rdd.Infra/Helpers/WebFilterConverter.cs
@@ -12,13 +12,18 @@ using System.Net.Mail;
 
 namespace Rdd.Infra.Helpers
 {
-    public class WebFilterConverter<TEntity> : IWebFilterConverter<TEntity>
+    public class WebFilterConverter
     {
-        private const int EF_EXPRESSION_TREE_MAX_DEPTH = 1000;
+        protected const int EF_EXPRESSION_TREE_MAX_DEPTH = 1000;
 
-        private static readonly HashSet<Type> KnownTypesEvaluatedClientSideWithHashCode
+        protected static readonly HashSet<Type> KnownTypesEvaluatedClientSideWithHashCode
             = new HashSet<Type> { typeof(MailAddress) };
 
+        protected WebFilterConverter() { }
+    }
+
+    public class WebFilterConverter<TEntity> : WebFilterConverter, IWebFilterConverter<TEntity>
+    {
         public Expression<Func<TEntity, bool>> ToExpression(IEnumerable<WebFilter<TEntity>> filters) => filters.Select(ToExpression).AndAggregation();
 
         public Expression<Func<TEntity, bool>> ToExpression(WebFilter<TEntity> filter)

--- a/test/Rdd.Domain.Tests/Models/User.cs
+++ b/test/Rdd.Domain.Tests/Models/User.cs
@@ -10,7 +10,8 @@ namespace Rdd.Domain.Tests.Models
         public string Name { get; set; }
         public string Url { get; set; }
 
-        public MailAddress Mail { get; set; }
+        public string MailString { get; set; }
+        public MailAddress Mail { get => new MailAddress(MailString); set => MailString = value?.ToString(); }
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }
         public Department Department { get; set; }
@@ -23,7 +24,13 @@ namespace Rdd.Domain.Tests.Models
 
             for (var i = 1; i <= count; i++)
             {
-                result.Add(new User { Id = Guid.NewGuid(), Name = $"John Doe {i}", FriendId = (i % 2 == 0 ? (Guid?)null : Guid.NewGuid()) });
+                result.Add(new User
+                {
+                    Id = Guid.NewGuid(),
+                    Name = $"John Doe {i}",
+                    FriendId = i % 2 == 0 ? (Guid?)null : Guid.NewGuid(),
+                    MailString = $"aaa{i}@example.com"
+                });
             }
 
             return result;

--- a/test/Rdd.Domain.Tests/Models/User.cs
+++ b/test/Rdd.Domain.Tests/Models/User.cs
@@ -11,7 +11,7 @@ namespace Rdd.Domain.Tests.Models
         public string Url { get; set; }
 
         public string MailString { get; set; }
-        public MailAddress Mail { get => new MailAddress(MailString); set => MailString = value?.ToString(); }
+        public MailAddress Mail { get => string.IsNullOrEmpty(MailString) ? null : new MailAddress(MailString); set => MailString = value?.ToString(); }
         public Uri TwitterUri { get; set; }
         public decimal Salary { get; set; }
         public Department Department { get; set; }

--- a/test/Rdd.Web.Tests/IntegrationTests.cs
+++ b/test/Rdd.Web.Tests/IntegrationTests.cs
@@ -1,0 +1,43 @@
+﻿using Rdd.Domain.Helpers;
+using Rdd.Domain.Tests;
+using Rdd.Domain.Tests.Models;
+using Rdd.Infra.Storage;
+using Rdd.Infra.Tests;
+using System.Linq;
+using Xunit;
+
+namespace Rdd.Web.Tests
+{
+    public class IntegrationTests : DatabaseTest, IClassFixture<DefaultFixture>
+    {
+        private DefaultFixture _fixture;
+
+        public IntegrationTests(DefaultFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        //ce test vérifie que la manière dont est convertie les filtres sur les mailsaddress fonctionne jusque dans EF
+        [Fact]
+        public async void MailAdressFiltersShouldWork()
+        {
+            await RunCodeInsideIsolatedDatabaseAsync(async (context) =>
+            {
+                var unitOfWork = new UnitOfWork(context, null);
+                var storage = new EFStorageService(context);
+                var repo = new UsersRepository(storage, _fixture.RightsService);
+                var collection = new UsersCollection(repo, _fixture.PatcherProvider, _fixture.Instanciator);
+                var users = User.GetManyRandomUsers(20).OrderBy(u => u.Id).ToList();
+                repo.AddRange(users);
+                await unitOfWork.SaveChangesAsync();
+
+                var request = HttpVerbs.Get.NewRequest(("mail", "aaa3@example.com"));
+                var query = QueryParserHelper.GetQueryParser<User>().Parse(request, true);
+                var result = (await collection.GetAsync(query)).Items;
+
+                Assert.Single(result);
+                Assert.Equal("John Doe 3", result.FirstOrDefault().Name);
+            }, true);
+        }
+    }
+}

--- a/test/Rdd.Web.Tests/Rdd.Web.Tests.csproj
+++ b/test/Rdd.Web.Tests/Rdd.Web.Tests.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\src\Rdd.Domain\Rdd.Domain.csproj" />
     <ProjectReference Include="..\..\src\Rdd.Web\Rdd.Web.csproj" />
     <ProjectReference Include="..\Rdd.Domain.Tests\Rdd.Domain.Tests.csproj" />
+    <ProjectReference Include="..\Rdd.Infra.Tests\Rdd.Infra.Tests.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
les filtres sur les types checkés côté client (tel que mailadress) doivent s'appuyer sur un .Contains plutot que sur comparaison d'égalité, car le résultat n'est pas le même. 

J'imagine que c'est la différence entre GetHashCode et Equals

lucca.auth utilise ce genre de filtre
https://github.com/LuccaSA/RestDrivenDomain/issues/272