### PR TITLE
Fix filter on collection + secu fix on filter on hidden navigation properties

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -102,7 +102,7 @@
  - **Added**: Inheritance support. To expose an API from a base class, use `RDDServiceCollectionExtensions.AddRddInheritanceConfiguration`. Then, Rdd will automatically take care of the rest for this API to work as expected. The interface `IInheritanceConfiguration` allows for the description of the diffetents classes to Rdd.
  - **Added**: `BaseClassInstanciator`, `BaseClassPatcher` and `BaseClassJsonConverter` to properly manage inheritance schemes during edition.
  - **Added**: `SerializerProvider.InheritanceConfigurations` and `BaseClassSerializer` to properly manage inheritance schemes during exposition.
- - **Added**: `ReadOnlyRepository<T>.IncludeWhiteList`. This allows an automatic white-list approach on the include on a Get query.
+ - **Added**: `IPropertyAuthorizer<T>`. This allows an automatic white-list approach on the include and filters on a Get query.
  - **Added**: New logic for property and member selection via expression coming from the web. The main interface to manipulate is `IExpression`, that replaces `PropertySelector`. The main implementation to use now are `PropertyExpression`, `EnumerablePropertyExpression`, `ItemExpression`, `ExpressionChain`, or `ExpressionTree`. The parsing and manipulation is ensured by `ExpressionParser (IExpressionParser)` and the visitors `ExpressionChainExtractor`, `ExpressionChainer`.
  - **Added**: `ExpressionEqualityComparer` to compare `Expression` and another one to compare `IExpression`.
  - **Added**: readable static method to construct `OrderBy`

--- a/src/Rdd.Infra/Storage/IPropertyAuthorizer.cs
+++ b/src/Rdd.Infra/Storage/IPropertyAuthorizer.cs
@@ -1,0 +1,11 @@
+﻿using Rdd.Domain.Helpers.Expressions;
+
+namespace Rdd.Infra.Storage
+{
+    public interface IPropertyAuthorizer<TEntity>
+    {
+        IExpressionTree IncludeWhiteList { get; }
+
+        bool IsVisible(IExpressionChain property);
+    }
+}

--- a/src/Rdd.Infra/Storage/PropertyAuthorizer.cs
+++ b/src/Rdd.Infra/Storage/PropertyAuthorizer.cs
@@ -1,0 +1,37 @@
+﻿using Rdd.Domain.Helpers.Expressions;
+using System.Linq;
+
+namespace Rdd.Infra.Storage
+{
+    public class PropertyAuthorizer<TEntity> : IPropertyAuthorizer<TEntity>
+    {
+        public virtual IExpressionTree IncludeWhiteList { get; }
+
+        public PropertyAuthorizer() : this(null) { }
+        public PropertyAuthorizer(IExpressionTree whiteList)
+        {
+            IncludeWhiteList = whiteList;
+        }
+
+        public virtual bool IsVisible(IExpressionChain property) => IsVisible(property, IncludeWhiteList);
+
+        protected virtual bool IsVisible(IExpressionChain property, IExpressionTree tree)
+        {
+            //leaves (actual properties) are visible, if base entity is visible
+            if (property?.Next == null)
+            {
+                return true;
+            }
+
+            if (tree == null)
+            {
+                return false;
+            }
+
+            var subTree = tree.Children.FirstOrDefault(c => c.Node.Equals(property.Current));
+
+            //property is not includable => not filterable either
+            return subTree != null && IsVisible(property.Next, subTree);
+        }
+    }
+}

--- a/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
+++ b/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Rdd.Domain;
-using Rdd.Domain.Helpers.Expressions;
 using Rdd.Domain.Models.Querying;
 using Rdd.Domain.Rights;
 using System.Collections.Generic;
@@ -14,13 +13,13 @@ namespace Rdd.Infra.Storage
     {
         protected IStorageService StorageService { get; set; }
         protected IRightExpressionsHelper<TEntity> RightExpressionsHelper { get; set; }
-
-        protected virtual IExpressionTree IncludeWhiteList { get; }
-
-        public ReadOnlyRepository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightExpressionsHelper)
+        protected IPropertyAuthorizer<TEntity> PropertyAuthorizer { get; set; }
+        
+        public ReadOnlyRepository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightExpressionsHelper, IPropertyAuthorizer<TEntity> propertyAuthorizer)
         {
             StorageService = storageService;
             RightExpressionsHelper = rightExpressionsHelper;
+            PropertyAuthorizer = propertyAuthorizer;
         }
 
         public virtual Task<int> CountAsync(Query<TEntity> query)
@@ -99,12 +98,12 @@ namespace Rdd.Infra.Storage
 
         protected virtual IQueryable<TEntity> ApplyIncludes(IQueryable<TEntity> entities, Query<TEntity> query)
         {
-            if (IncludeWhiteList == null || query.Fields == null)
+            if (PropertyAuthorizer.IncludeWhiteList == null || query.Fields == null)
             {
                 return entities;
             }
 
-            foreach (var prop in query.Fields.Intersection(IncludeWhiteList))
+            foreach (var prop in query.Fields.Intersection(PropertyAuthorizer.IncludeWhiteList))
             {
                 entities = entities.Include(prop.Name);
             }

--- a/src/Rdd.Infra/Storage/Repository.cs
+++ b/src/Rdd.Infra/Storage/Repository.cs
@@ -7,8 +7,8 @@ namespace Rdd.Infra.Storage
     public class Repository<TEntity> : ReadOnlyRepository<TEntity>, IRepository<TEntity>
         where TEntity : class
     {
-        public Repository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightExpressionsHelper)
-            : base(storageService, rightExpressionsHelper) { }
+        public Repository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightExpressionsHelper, IPropertyAuthorizer<TEntity> propertyAuthorizer)
+            : base(storageService, rightExpressionsHelper, propertyAuthorizer) { }
 
         public virtual void Add(TEntity entity)
         {

--- a/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -70,7 +70,7 @@ namespace Rdd.Web.Helpers
             services.TryAddSingleton(typeof(IPropertyAuthorizer<>), typeof(PropertyAuthorizer<>));
             services.TryAddSingleton(typeof(IFilterParser<>), typeof(FilterParser<>));
             services.TryAddSingleton<IFieldsParser, FieldsParser>();
-            services.TryAddSingleton<IOrderByParser, OrderByParser>();
+            services.TryAddSingleton(typeof(IOrderByParser<>), typeof(OrderByParser<>));
             services.TryAddSingleton(typeof(IQueryParser<>), typeof(QueryParser<>));
 
             //scoped services

--- a/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -67,7 +67,8 @@ namespace Rdd.Web.Helpers
             services.TryAddSingleton<IExpressionParser, ExpressionParser>();
             services.TryAddSingleton(typeof(IWebFilterConverter<>), typeof(WebFilterConverter<>));
             services.TryAddSingleton<IPagingParser, PagingParser>();
-            services.TryAddSingleton<IFilterParser, FilterParser>();
+            services.TryAddSingleton(typeof(IPropertyAuthorizer<>), typeof(PropertyAuthorizer<>));
+            services.TryAddSingleton(typeof(IFilterParser<>), typeof(FilterParser<>));
             services.TryAddSingleton<IFieldsParser, FieldsParser>();
             services.TryAddSingleton<IOrderByParser, OrderByParser>();
             services.TryAddSingleton(typeof(IQueryParser<>), typeof(QueryParser<>));

--- a/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ namespace Rdd.Web.Helpers
             services.TryAddSingleton<ISerializerProvider, SerializerProvider>();
 
             services.TryAddSingleton<ArraySerializer>();
+            services.TryAddSingleton<IFieldsParser, FieldsParser>();
             services.TryAddSingleton<BaseClassSerializer>();
             services.TryAddSingleton<CultureInfoSerializer>();
             services.TryAddSingleton<DictionarySerializer>();
@@ -69,7 +70,7 @@ namespace Rdd.Web.Helpers
             services.TryAddSingleton<IPagingParser, PagingParser>();
             services.TryAddSingleton(typeof(IPropertyAuthorizer<>), typeof(PropertyAuthorizer<>));
             services.TryAddSingleton(typeof(IFilterParser<>), typeof(FilterParser<>));
-            services.TryAddSingleton<IFieldsParser, FieldsParser>();
+            services.TryAddSingleton(typeof(IFieldsParser<>), typeof(FieldsParser<>));
             services.TryAddSingleton(typeof(IOrderByParser<>), typeof(OrderByParser<>));
             services.TryAddSingleton(typeof(IQueryParser<>), typeof(QueryParser<>));
 

--- a/src/Rdd.Web/Querying/FilterParser.cs
+++ b/src/Rdd.Web/Querying/FilterParser.cs
@@ -19,8 +19,7 @@ using System.Linq;
 
 namespace Rdd.Web.Querying
 {
-    public class FilterParser<TEntity> : IFilterParser<TEntity>
-        where TEntity : class
+    public class FilterParser
     {
         protected static readonly IReadOnlyDictionary<StringSegment, WebFilterOperand> Operands = new Dictionary<StringSegment, WebFilterOperand>(StringSegmentComparer.OrdinalIgnoreCase)
         {
@@ -37,6 +36,12 @@ namespace Rdd.Web.Querying
             {"lessthanorequal", WebFilterOperand.LessThanOrEqual}
         };
 
+        protected FilterParser() { }
+    }
+
+    public class FilterParser<TEntity> : FilterParser, IFilterParser<TEntity>
+        where TEntity : class
+    {
         private readonly IStringConverter _stringConverter;
         private readonly IExpressionParser _expressionParser;
         private readonly IWebFilterConverter<TEntity> _webFilterConverter;

--- a/src/Rdd.Web/Querying/IFieldsParser.cs
+++ b/src/Rdd.Web/Querying/IFieldsParser.cs
@@ -7,6 +7,10 @@ namespace Rdd.Web.Querying
     public interface IFieldsParser
     {
         IExpressionTree ParseDefaultFields(Type type);
-        IExpressionTree<TEntity> Parse<TEntity>(HttpRequest request, bool isCollectionCall);
+    }
+
+    public interface IFieldsParser<TEntity>
+    {
+        IExpressionTree<TEntity> Parse(HttpRequest request, bool isCollectionCall);
     }
 }

--- a/src/Rdd.Web/Querying/IFilterParser.cs
+++ b/src/Rdd.Web/Querying/IFilterParser.cs
@@ -1,19 +1,16 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Rdd.Domain.Models.Querying;
-using Rdd.Infra.Helpers;
 using Rdd.Infra.Web.Models;
 
 namespace Rdd.Web.Querying
 {
-    public interface IFilterParser
+    public interface IFilterParser<TEntity>
+        where TEntity : class
     {
-        Filter<TEntity> Parse<TEntity>(HttpRequest request, IWebFilterConverter<TEntity> webFilterConverter)
-            where TEntity : class;
+        Filter<TEntity> Parse(HttpRequest request);
+        Filter<TEntity> Parse(HttpRequest request, ActionDescriptor action);
 
-        Filter<TEntity> Parse<TEntity>(HttpRequest request, ActionDescriptor action, IWebFilterConverter<TEntity> webFilterConverter)
-            where TEntity : class;
-
-        WebFilter<TEntity> Parse<TEntity>(string key, string value);
+        WebFilter<TEntity> Parse(string key, string value);
     }
 }

--- a/src/Rdd.Web/Querying/IOrderByParser.cs
+++ b/src/Rdd.Web/Querying/IOrderByParser.cs
@@ -4,8 +4,9 @@ using Rdd.Domain.Models.Querying;
 
 namespace Rdd.Web.Querying
 {
-    public interface IOrderByParser
+    public interface IOrderByParser<TEntity>
+         where TEntity : class
     {
-        List<OrderBy<TEntity>> Parse<TEntity>(HttpRequest request) where TEntity : class;
+        List<OrderBy<TEntity>> Parse(HttpRequest request);
     }
 }

--- a/src/Rdd.Web/Querying/QueryParser.cs
+++ b/src/Rdd.Web/Querying/QueryParser.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc.Abstractions;
 using Rdd.Domain;
 using Rdd.Domain.Helpers;
 using Rdd.Domain.Models.Querying;
-using Rdd.Infra.Helpers;
 using System;
 
 namespace Rdd.Web.Querying
@@ -14,9 +13,9 @@ namespace Rdd.Web.Querying
         private readonly IPagingParser _pagingParser;
         private readonly IFilterParser<TEntity> _filterParser;
         private readonly IFieldsParser _fieldsParser;
-        private readonly IOrderByParser _orderByParser;
+        private readonly IOrderByParser<TEntity> _orderByParser;
 
-        public QueryParser(IPagingParser pagingParser, IFilterParser<TEntity> filterParser, IFieldsParser fieldsParser, IOrderByParser orderByParser)
+        public QueryParser(IPagingParser pagingParser, IFilterParser<TEntity> filterParser, IFieldsParser fieldsParser, IOrderByParser<TEntity> orderByParser)
         {
             _pagingParser = pagingParser ?? throw new ArgumentNullException(nameof(pagingParser));
             _filterParser = filterParser ?? throw new ArgumentNullException(nameof(filterParser));
@@ -32,7 +31,7 @@ namespace Rdd.Web.Querying
             var query = new Query<TEntity>
             (
                  _fieldsParser.Parse<TEntity>(request, isCollectionCall),
-                 _orderByParser.Parse<TEntity>(request),
+                 _orderByParser.Parse(request),
                  _pagingParser.Parse(request),
                  _filterParser.Parse(request, action),
                 GetVerb(request)

--- a/src/Rdd.Web/Querying/QueryParser.cs
+++ b/src/Rdd.Web/Querying/QueryParser.cs
@@ -12,10 +12,10 @@ namespace Rdd.Web.Querying
     {
         private readonly IPagingParser _pagingParser;
         private readonly IFilterParser<TEntity> _filterParser;
-        private readonly IFieldsParser _fieldsParser;
+        private readonly IFieldsParser<TEntity> _fieldsParser;
         private readonly IOrderByParser<TEntity> _orderByParser;
 
-        public QueryParser(IPagingParser pagingParser, IFilterParser<TEntity> filterParser, IFieldsParser fieldsParser, IOrderByParser<TEntity> orderByParser)
+        public QueryParser(IPagingParser pagingParser, IFilterParser<TEntity> filterParser, IFieldsParser<TEntity> fieldsParser, IOrderByParser<TEntity> orderByParser)
         {
             _pagingParser = pagingParser ?? throw new ArgumentNullException(nameof(pagingParser));
             _filterParser = filterParser ?? throw new ArgumentNullException(nameof(filterParser));
@@ -30,7 +30,7 @@ namespace Rdd.Web.Querying
         {
             var query = new Query<TEntity>
             (
-                 _fieldsParser.Parse<TEntity>(request, isCollectionCall),
+                 _fieldsParser.Parse(request, isCollectionCall),
                  _orderByParser.Parse(request),
                  _pagingParser.Parse(request),
                  _filterParser.Parse(request, action),

--- a/src/Rdd.Web/Querying/QueryParser.cs
+++ b/src/Rdd.Web/Querying/QueryParser.cs
@@ -11,15 +11,13 @@ namespace Rdd.Web.Querying
     public class QueryParser<TEntity> : IQueryParser<TEntity>
         where TEntity : class
     {
-        private readonly IWebFilterConverter<TEntity> _webFilterConverter;
         private readonly IPagingParser _pagingParser;
-        private readonly IFilterParser _filterParser;
+        private readonly IFilterParser<TEntity> _filterParser;
         private readonly IFieldsParser _fieldsParser;
         private readonly IOrderByParser _orderByParser;
 
-        public QueryParser(IWebFilterConverter<TEntity> webFilterConverter, IPagingParser pagingParser, IFilterParser filterParser, IFieldsParser fieldsParser, IOrderByParser orderByParser)
+        public QueryParser(IPagingParser pagingParser, IFilterParser<TEntity> filterParser, IFieldsParser fieldsParser, IOrderByParser orderByParser)
         {
-            _webFilterConverter = webFilterConverter ?? throw new ArgumentNullException(nameof(webFilterConverter));
             _pagingParser = pagingParser ?? throw new ArgumentNullException(nameof(pagingParser));
             _filterParser = filterParser ?? throw new ArgumentNullException(nameof(filterParser));
             _fieldsParser = fieldsParser ?? throw new ArgumentNullException(nameof(fieldsParser));
@@ -36,7 +34,7 @@ namespace Rdd.Web.Querying
                  _fieldsParser.Parse<TEntity>(request, isCollectionCall),
                  _orderByParser.Parse<TEntity>(request),
                  _pagingParser.Parse(request),
-                 _filterParser.Parse(request, action, _webFilterConverter),
+                 _filterParser.Parse(request, action),
                 GetVerb(request)
             );
 

--- a/test/Rdd.Domain.Tests/AbstractEntityTests.cs
+++ b/test/Rdd.Domain.Tests/AbstractEntityTests.cs
@@ -27,7 +27,7 @@ namespace Rdd.Domain.Tests
         {
             var rightsService = new OpenRightExpressionsHelper<ConcreteClassThree>();
             var storage = new InMemoryStorageService();
-            var repo = new OpenRepository<ConcreteClassThree>(storage, rightsService);
+            var repo = new OpenRepository<ConcreteClassThree>(storage, rightsService, new PropertyAuthorizer<ConcreteClassThree>());
 
             repo.Add(new ConcreteClassThree());
             repo.Add(new ConcreteClassThree());
@@ -44,7 +44,7 @@ namespace Rdd.Domain.Tests
         {
             var rightsService = new OpenRightExpressionsHelper<AbstractClass>();
             var storage = new InMemoryStorageService();
-            var repo = new OpenRepository<AbstractClass>(storage, rightsService);
+            var repo = new OpenRepository<AbstractClass>(storage, rightsService, new PropertyAuthorizer<AbstractClass>());
 
             repo.Add(new ConcreteClassOne());
             repo.Add(new ConcreteClassOne());

--- a/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
+++ b/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
@@ -62,7 +62,7 @@ namespace Rdd.Domain.Tests
             rightService.Setup(s => s.GetFilter(It.IsAny<Query<User>>())).Returns(trueFilter);
 
             var id = Guid.NewGuid();
-            var repo = new Repository<User>(_fixture.InMemoryStorage, rightService.Object);
+            var repo = new Repository<User>(_fixture.InMemoryStorage, rightService.Object, new PropertyAuthorizer<User>());
             var users = new UsersCollection(repo, _fixture.PatcherProvider, _fixture.Instanciator);
             var app = new UsersAppController(_fixture.InMemoryStorage, users);
             var candidate1 = _parser.Parse<User, Guid>($@"{{ ""id"": ""{id}"" }}");
@@ -97,7 +97,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task Post_SHOULD_work_WHEN_InstantiateEntityIsOverridenAndEntityHasParametersInConstructor()
         {
-            var repo = new Repository<UserWithParameters>(_fixture.InMemoryStorage, new OpenRightExpressionsHelper<UserWithParameters>());
+            var repo = new Repository<UserWithParameters>(_fixture.InMemoryStorage, new OpenRightExpressionsHelper<UserWithParameters>(), new PropertyAuthorizer<UserWithParameters>());
             var users = new UsersCollectionWithParameters(repo, _fixture.PatcherProvider, new InstanciatorImplementation());
             var query = new Query<UserWithParameters>();
             query.Options.CheckRights = false;
@@ -196,7 +196,7 @@ namespace Rdd.Domain.Tests
         {
             Assert.ThrowsAsync<BadRequestException>(async () =>
             {
-                var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
+                var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object, new PropertyAuthorizer<Hierarchy>());
                 var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
                 var collection = new RestCollection<Hierarchy, int>(repo, new ObjectPatcher<Hierarchy>(_fixture.PatcherProvider, _fixture.ReflectionHelper), instanciator);
 
@@ -208,7 +208,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task BaseClass_Collection_on_hierarchy_works()
         {
-            var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
+            var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object, new PropertyAuthorizer<Hierarchy>());
             var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
             var collection = new RestCollection<Hierarchy, int>(repo, new BaseClassPatcher<Hierarchy>(_fixture.PatcherProvider, _fixture.ReflectionHelper, new InheritanceConfiguration()), instanciator);
 

--- a/test/Rdd.Domain.Tests/DefaultFixture.cs
+++ b/test/Rdd.Domain.Tests/DefaultFixture.cs
@@ -37,7 +37,7 @@ namespace Rdd.Domain.Tests
             RightsService = new OpenRightExpressionsHelper<User>();
             Instanciator = new DefaultInstanciator<User>();
             InMemoryStorage = new InMemoryStorageService();
-            UsersRepo = new Repository<User>(InMemoryStorage, RightsService);
+            UsersRepo = new Repository<User>(InMemoryStorage, RightsService, new PropertyAuthorizer<User>());
         }
 
         public void Dispose() { }

--- a/test/Rdd.Domain.Tests/Models/OpenRepository.cs
+++ b/test/Rdd.Domain.Tests/Models/OpenRepository.cs
@@ -8,8 +8,8 @@ namespace Rdd.Domain.Tests.Models
     public class OpenRepository<TEntity> : Repository<TEntity>
         where TEntity : class
     {
-        public OpenRepository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightsService)
-        : base(storageService, rightsService) { }
+        public OpenRepository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightsService, IPropertyAuthorizer<TEntity> propertyAuthorizer)
+        : base(storageService, rightsService, propertyAuthorizer) { }
 
         protected override IQueryable<TEntity> ApplyRights(IQueryable<TEntity> entities, Query<TEntity> query)
         {

--- a/test/Rdd.Infra.Tests/Storage/PropertyAuthorizerTests.cs
+++ b/test/Rdd.Infra.Tests/Storage/PropertyAuthorizerTests.cs
@@ -1,0 +1,28 @@
+﻿using Rdd.Domain.Helpers.Expressions;
+using Rdd.Domain.Tests.Models;
+using Rdd.Infra.Storage;
+using Xunit;
+
+namespace Rdd.Infra.Tests.Storage
+{
+    public class PropertyAuthorizerTests
+    {
+        [Theory]
+        [InlineData(null, null, true)]
+        [InlineData(null, "name", true)]
+        [InlineData(null, "department", true)]
+        [InlineData(null, "department.name", false)]
+        [InlineData("department", "department.name", true)]
+        [InlineData(null, "department.users", false)]
+        [InlineData("department", "department.users", true)]
+        [InlineData("department", "department.users.id", false)]
+        [InlineData("department.users", "department.users.id", true)]
+        [InlineData("department.users.Department", "department.users.id", true)]
+        public void PropertyAuthorizer(string whiteList, string input, bool result)
+        {
+            var parser = new ExpressionParser();
+            var authorizer = whiteList == null ? new PropertyAuthorizer<User>() : new PropertyAuthorizer<User>(parser.ParseTree<User>(whiteList));
+            Assert.Equal(result, authorizer.IsVisible(input == null ? null : parser.ParseChain<User>(input)));
+        }
+    }
+}

--- a/test/Rdd.Infra.Tests/Storage/StorageTests.cs
+++ b/test/Rdd.Infra.Tests/Storage/StorageTests.cs
@@ -60,7 +60,7 @@ namespace Rdd.Infra.Tests.Storage
         [Fact]
         public async Task RepoOnNullFilterDoesNotFail()
         {
-            var repo = new Repository<User>(new InMemoryStorageService(), new OpenRightExpressionsHelper<User>());
+            var repo = new Repository<User>(new InMemoryStorageService(), new OpenRightExpressionsHelper<User>(), new PropertyAuthorizer<User>());
             repo.Add(new User());
 
             var count = await repo.CountAsync(new Query<User> { Filter = null });

--- a/test/Rdd.Infra.Tests/UsersRepository.cs
+++ b/test/Rdd.Infra.Tests/UsersRepository.cs
@@ -7,13 +7,16 @@ using System.Linq;
 
 namespace Rdd.Infra.Tests
 {
-    public class UsersRepository : OpenRepository<User>
+    public class UserPropertyAuthorizer : PropertyAuthorizer<User>
     {
         private static readonly IExpressionTree WhiteList = new ExpressionParser().ParseTree<User>(nameof(User.Department));
-        protected override IExpressionTree IncludeWhiteList => WhiteList;
+        public override IExpressionTree IncludeWhiteList => WhiteList;
+    }
 
+    public class UsersRepository : OpenRepository<User>
+    {
         public UsersRepository(IStorageService storageService, IRightExpressionsHelper<User> rightsService)
-        : base(storageService, rightsService) { }
+        : base(storageService, rightsService, new UserPropertyAuthorizer()) { }
 
         protected override IQueryable<User> ApplyOrderBys(IQueryable<User> entities, Query<User> query)
         {

--- a/test/Rdd.Web.Tests/CollectionPropertiesTests.cs
+++ b/test/Rdd.Web.Tests/CollectionPropertiesTests.cs
@@ -18,7 +18,7 @@ namespace Rdd.Web.Tests
         {
             _fixture = fixture;
             _storage = new InMemoryStorageService();
-            _repo = new OpenRepository<User>(_storage, _fixture.RightsService);
+            _repo = new OpenRepository<User>(_storage, _fixture.RightsService, new PropertyAuthorizer<User>());
             _collection = new UsersCollection(_repo, _fixture.PatcherProvider, _fixture.Instanciator);
         }
 

--- a/test/Rdd.Web.Tests/Models/Department.cs
+++ b/test/Rdd.Web.Tests/Models/Department.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 
 namespace Rdd.Web.Tests.Models
 {
-    
     public enum Test { A = 0, B = 10 }
+
     public class Department : EntityBase<int>
     {
         public ICollection<User> Users { get; set; }

--- a/test/Rdd.Web.Tests/Models/User.cs
+++ b/test/Rdd.Web.Tests/Models/User.cs
@@ -1,5 +1,6 @@
 ﻿using Rdd.Domain.Models;
 using System;
+using System.Collections.Generic;
 
 namespace Rdd.Web.Tests.Models
 {
@@ -12,5 +13,7 @@ namespace Rdd.Web.Tests.Models
         public Guid PictureId { get; set; }
         public DateTime? BirthDay { get; set; }
         public DateTime ContractStart { get; set; }
+
+        public List<Department> Departments { get; set; }
     }
 }

--- a/test/Rdd.Web.Tests/QueryBuilderTests.cs
+++ b/test/Rdd.Web.Tests/QueryBuilderTests.cs
@@ -112,6 +112,36 @@ namespace Rdd.Web.Tests
             Assert.Equal(users[1], nullUser);
         }
 
+        [Fact]
+        public void ComplexProperty()
+        {
+            var builder = new WebFilterConverter<User>();
+            var goodUser = new User { Departments = new List<Department> { new Department { Id = 1 } } };
+            var badUser = new User { Departments = new List<Department> { new Department { Id = 3 } } };
+
+            var property = new ExpressionParser().ParseChain<User>("Departments.Id");
+            var filter = new WebFilter<User>(property, WebFilterOperand.Equals, new List<int> { 1, 2 });
+            var expression = builder.ToExpression(filter);
+            var users = new List<User> { goodUser, badUser }.AsQueryable().Where(expression).ToList();
+            Assert.Single(users);
+            Assert.Equal(users[0], goodUser);
+        }
+
+        [Fact]
+        public void VeryComplexProperty()
+        {
+            var builder = new WebFilterConverter<User>();
+            var goodUser = new User { Departments = new List<Department> { new Department { Users = new List<User> { new User { Id = 1 } } } } };
+            var badUser = new User { Departments = new List<Department> { new Department { Users = new List<User> { new User { Id = 3 } } } } };
+
+            var property = new ExpressionParser().ParseChain<User>("Departments.Users.Id");
+            var filter = new WebFilter<User>(property, WebFilterOperand.Equals, new List<int> { 1, 2 });
+            var expression = builder.ToExpression(filter);
+            var users = new List<User> { goodUser, badUser }.AsQueryable().Where(expression).ToList();
+            Assert.Single(users);
+            Assert.Equal(users[0], goodUser);
+        }
+
         [Theory]
         [InlineData(1)]
         [InlineData(1, 2)]

--- a/test/Rdd.Web.Tests/QueryParserHelper.cs
+++ b/test/Rdd.Web.Tests/QueryParserHelper.cs
@@ -16,7 +16,7 @@ namespace Rdd.Web.Tests
             var opt = Options.Create(rddOptions ?? new RddOptions());
             var authorizer = new PropertyAuthorizer<T>(whiteList);
             var parser = new ExpressionParser();
-            return new QueryParser<T>(new PagingParser(opt), new FilterParser<T>(new StringConverter(), parser, new WebFilterConverter<T>(), authorizer), new FieldsParser(parser), new OrderByParser<T>(parser, authorizer));
+            return new QueryParser<T>(new PagingParser(opt), new FilterParser<T>(new StringConverter(), parser, new WebFilterConverter<T>(), authorizer), new FieldsParser<T>(parser, authorizer), new OrderByParser<T>(parser, authorizer));
         }
     }
 }

--- a/test/Rdd.Web.Tests/QueryParserHelper.cs
+++ b/test/Rdd.Web.Tests/QueryParserHelper.cs
@@ -1,6 +1,7 @@
 ﻿using Rdd.Domain.Helpers.Expressions;
 using Rdd.Domain.Models.Querying;
 using Rdd.Infra.Helpers;
+using Rdd.Infra.Storage;
 using Rdd.Web.Helpers;
 using Rdd.Web.Querying;
 using Options = Microsoft.Extensions.Options.Options;
@@ -9,11 +10,11 @@ namespace Rdd.Web.Tests
 {
     public static class QueryParserHelper
     {
-        public static QueryParser<T> GetQueryParser<T>(RddOptions rddOptions = null)
+        public static QueryParser<T> GetQueryParser<T>(RddOptions rddOptions = null, IExpressionTree whiteList = null)
             where T : class
         {
             var opt = Options.Create(rddOptions ?? new RddOptions());
-            return new QueryParser<T>(new WebFilterConverter<T>(), new PagingParser(opt), new FilterParser(new StringConverter(), new ExpressionParser()), new FieldsParser(new ExpressionParser()), new OrderByParser(new ExpressionParser()));
+            return new QueryParser<T>(new PagingParser(opt), new FilterParser<T>(new StringConverter(), new ExpressionParser(), new WebFilterConverter<T>(), new PropertyAuthorizer<T>(whiteList)), new FieldsParser(new ExpressionParser()), new OrderByParser(new ExpressionParser()));
         }
     }
 }

--- a/test/Rdd.Web.Tests/QueryParserHelper.cs
+++ b/test/Rdd.Web.Tests/QueryParserHelper.cs
@@ -14,7 +14,9 @@ namespace Rdd.Web.Tests
             where T : class
         {
             var opt = Options.Create(rddOptions ?? new RddOptions());
-            return new QueryParser<T>(new PagingParser(opt), new FilterParser<T>(new StringConverter(), new ExpressionParser(), new WebFilterConverter<T>(), new PropertyAuthorizer<T>(whiteList)), new FieldsParser(new ExpressionParser()), new OrderByParser(new ExpressionParser()));
+            var authorizer = new PropertyAuthorizer<T>(whiteList);
+            var parser = new ExpressionParser();
+            return new QueryParser<T>(new PagingParser(opt), new FilterParser<T>(new StringConverter(), parser, new WebFilterConverter<T>(), authorizer), new FieldsParser(parser), new OrderByParser<T>(parser, authorizer));
         }
     }
 }

--- a/test/Rdd.Web.Tests/QueryParserTests.cs
+++ b/test/Rdd.Web.Tests/QueryParserTests.cs
@@ -13,11 +13,11 @@ using Xunit;
 namespace Rdd.Web.Tests
 {
     public class QueryParserTests
-    { 
+    {
         [Fact]
         public void CountParseHasOptionImplications()
         {
-            var request = HttpVerbs.Get.NewRequest(("fields", "collection.count")); 
+            var request = HttpVerbs.Get.NewRequest(("fields", "collection.count"));
             var query = QueryParserHelper.GetQueryParser<User>().Parse(request, true);
 
             Assert.True(query.Options.NeedCount);
@@ -27,7 +27,7 @@ namespace Rdd.Web.Tests
         [Fact]
         public void IgnoredAndBadFilters()
         {
-            var request = HttpVerbs.Get.NewRequest(   ("", "oulala") );
+            var request = HttpVerbs.Get.NewRequest(("", "oulala"));
 
             var options = new RddOptions();
             var parser = QueryParserHelper.GetQueryParser<User>(options);
@@ -111,7 +111,7 @@ namespace Rdd.Web.Tests
         [InlineData("20,10", 20, 10)]
         public void CorrectPaging(string input, int offset, int limit)
         {
-            var request = HttpVerbs.Get.NewRequest(("paging", input)); 
+            var request = HttpVerbs.Get.NewRequest(("paging", input));
 
             var query = QueryParserHelper.GetQueryParser<User>().Parse(request, true);
 
@@ -136,9 +136,10 @@ namespace Rdd.Web.Tests
         [InlineData("iddddd", "zef")]
         [InlineData("id", "zef")]
         [InlineData("id", "between,aaa,zzz")]
+        [InlineData("departments.users.id", "23")]//forbidden
         public void InCorrectFilter(string key, string value)
         {
-            var request = HttpVerbs.Get.NewRequest((key, value)); 
+            var request = HttpVerbs.Get.NewRequest((key, value));
 
             Assert.Throws<BadRequestException>(() => QueryParserHelper.GetQueryParser<User>().Parse(request, true));
         }
@@ -150,7 +151,7 @@ namespace Rdd.Web.Tests
         {
             var request = HttpVerbs.Get.NewRequest((key, "23"));
 
-            var query = QueryParserHelper.GetQueryParser<User>().Parse(request, true);
+            var query = QueryParserHelper.GetQueryParser<User>(whiteList: new ExpressionParser().ParseTree<User>(key)).Parse(request, true);
         }
     }
 }

--- a/test/Rdd.Web.Tests/QueryParserTests.cs
+++ b/test/Rdd.Web.Tests/QueryParserTests.cs
@@ -60,7 +60,7 @@ namespace Rdd.Web.Tests
         public void CorrectOrderBys(string input, SortDirection direction, string output)
         {
             var request = HttpVerbs.Get.NewRequest(("orderby", input));
-            var query = QueryParserHelper.GetQueryParser<User>().Parse(request, true);
+            var query = QueryParserHelper.GetQueryParser<User>(whiteList: new ExpressionParser().ParseTree<User>("department")).Parse(request, true);
 
             Assert.Single(query.OrderBys);
             Assert.Equal(direction, query.OrderBys[0].Direction);
@@ -84,6 +84,14 @@ namespace Rdd.Web.Tests
         [InlineData("Department,asc")]
         [InlineData("Department.Users,asc")]
         public void IncorrectOrderBys(string input)
+        {
+            var request = HttpVerbs.Get.NewRequest(("orderby", input));
+            Assert.Throws<BadRequestException>(() => QueryParserHelper.GetQueryParser<User>(whiteList: new ExpressionParser().ParseTree<User>("department.users")).Parse(request, true));
+        }
+
+        [Theory]
+        [InlineData("Department.id,asc")]
+        public void UnauthorizedOrderBys(string input)
         {
             var request = HttpVerbs.Get.NewRequest(("orderby", input));
             Assert.Throws<BadRequestException>(() => QueryParserHelper.GetQueryParser<User>().Parse(request, true));

--- a/test/Rdd.Web.Tests/QueryParserTests.cs
+++ b/test/Rdd.Web.Tests/QueryParserTests.cs
@@ -24,6 +24,34 @@ namespace Rdd.Web.Tests
             Assert.False(query.Options.NeedEnumeration);
         }
 
+        [Theory]
+        [InlineData("MyValueObject")]
+        [InlineData("TwitterUri")]
+        [InlineData("Salary")]
+        [InlineData("PictureId")]
+        [InlineData("BirthDay")]
+        [InlineData("ContractStart")]
+        [InlineData("Department")]
+        [InlineData("Department.id")]
+        public void CorrectFields(string input)
+        {
+            var request = HttpVerbs.Get.NewRequest(("fields", input));
+            var query = QueryParserHelper.GetQueryParser<User>(whiteList: new ExpressionParser().ParseTree<User>("department")).Parse(request, true);
+
+            Assert.True(query.Fields.Contains(new ExpressionParser().ParseChain<User>(input)));
+        }
+
+        [Theory]
+        [InlineData("bla")]
+        [InlineData("MyValueObject.bla")]
+        [InlineData("Department.enum")]//unauthorized
+        [InlineData("Departments.users")]//unauthorized
+        public void IncorrectFields(string input)
+        {
+            var request = HttpVerbs.Get.NewRequest(("fields", input));
+            Assert.Throws<BadRequestException>(() => QueryParserHelper.GetQueryParser<User>().Parse(request, true));
+        }
+
         [Fact]
         public void IgnoredAndBadFilters()
         {

--- a/test/Rdd.Web.Tests/QueryParserTests.cs
+++ b/test/Rdd.Web.Tests/QueryParserTests.cs
@@ -13,8 +13,7 @@ using Xunit;
 namespace Rdd.Web.Tests
 {
     public class QueryParserTests
-    {
- 
+    { 
         [Fact]
         public void CountParseHasOptionImplications()
         {
@@ -142,6 +141,16 @@ namespace Rdd.Web.Tests
             var request = HttpVerbs.Get.NewRequest((key, value)); 
 
             Assert.Throws<BadRequestException>(() => QueryParserHelper.GetQueryParser<User>().Parse(request, true));
+        }
+
+        [Theory]
+        [InlineData("departments.id")]
+        [InlineData("departments.users.id")]
+        public void CorrectFilter(string key)
+        {
+            var request = HttpVerbs.Get.NewRequest((key, "23"));
+
+            var query = QueryParserHelper.GetQueryParser<User>().Parse(request, true);
         }
     }
 }

--- a/test/Rdd.Web.Tests/Serialization/FieldsTests.cs
+++ b/test/Rdd.Web.Tests/Serialization/FieldsTests.cs
@@ -63,7 +63,7 @@ namespace Rdd.Web.Tests.Serialization
             services.AddSingleton<IPagingParser, PagingParser>();
             services.AddSingleton(typeof(IFilterParser<>), typeof(FilterParser<>));
             services.AddSingleton<IFieldsParser, FieldsParser>();
-            services.AddSingleton<IOrderByParser, OrderByParser>();
+            services.AddSingleton(typeof(IOrderByParser<>), typeof(OrderByParser<>));
             services.AddSingleton(typeof(IQueryParser<>), typeof(QueryParser<>));
 
             var urlProvider = new Mock<IUrlProvider>();

--- a/test/Rdd.Web.Tests/Serialization/FieldsTests.cs
+++ b/test/Rdd.Web.Tests/Serialization/FieldsTests.cs
@@ -61,7 +61,7 @@ namespace Rdd.Web.Tests.Serialization
             services.AddSingleton<IExpressionParser, ExpressionParser>();
             services.AddSingleton(typeof(IWebFilterConverter<>), typeof(WebFilterConverter<>));
             services.AddSingleton<IPagingParser, PagingParser>();
-            services.AddSingleton<IFilterParser, FilterParser>();
+            services.AddSingleton(typeof(IFilterParser<>), typeof(FilterParser<>));
             services.AddSingleton<IFieldsParser, FieldsParser>();
             services.AddSingleton<IOrderByParser, OrderByParser>();
             services.AddSingleton(typeof(IQueryParser<>), typeof(QueryParser<>));

--- a/test/Rdd.Web.Tests/WebControllerTests.cs
+++ b/test/Rdd.Web.Tests/WebControllerTests.cs
@@ -16,7 +16,7 @@ namespace Rdd.Web.Tests
         {
             var storage = new InMemoryStorageService();
 
-            var repository = new Repository<IUser>(storage, null);
+            var repository = new Repository<IUser>(storage, null, new PropertyAuthorizer<IUser>());
             var collection = new ReadOnlyRestCollection<IUser, int>(repository);
             var appController = new ReadOnlyAppController<IUser, int>(collection);
 

--- a/test/Rdd.Web.Tests/WebPagingTests.cs
+++ b/test/Rdd.Web.Tests/WebPagingTests.cs
@@ -22,7 +22,7 @@ namespace Rdd.Web.Tests
         {
             _fixture = fixture;
             _storage = new InMemoryStorageService();
-            _repo = new OpenRepository<User>(_storage, _fixture.RightsService);
+            _repo = new OpenRepository<User>(_storage, _fixture.RightsService, new PropertyAuthorizer<User>());
             _collection = new UsersCollection(_repo, _fixture.PatcherProvider, _fixture.Instanciator);
         }
 


### PR DESCRIPTION
Two things here

 - I found a bug on filters on collection properties. Filter such as ``?users.id=23`` stopped working since the refactoring on propertySelector.
(I'd love to use next version of nextends for this, https://github.com/LuccaSA/NExtends/pull/65)

 - As I was about to start the PR, I wondered if this would open security issues, notably with potential filters on unsafe properties (?users.salary>1000). And then, I realized, that this problem already existed and needed to be fixed now. So the second commit fixes just that, by extracting the actual "IncludeWhiteList" from repositories into a new interface `IPropertyAuthorizer`, that handles include as well as filters. So filters on unaccessible properties now throw instead of triggering the include/sql query.

This comes with small breaking changes, but I strongly recommend to ship it for the v3, as this is a security fix before all.