### PR TITLE
ENH : instanciator performances

### DIFF
--- a/Benchmarks/Serialization/Instanciators.cs
+++ b/Benchmarks/Serialization/Instanciators.cs
@@ -1,0 +1,95 @@
+﻿using BenchmarkDotNet.Attributes;
+using Rdd.Domain;
+using Rdd.Domain.Models;
+using System;
+using System.Linq.Expressions;
+using System.Reflection.Emit;
+
+namespace Rdd.Benchmarks
+{
+    public class ExpressionInstanciator<TEntity> : IInstanciator<TEntity>
+        where TEntity : class, new()
+    {
+        private readonly Func<TEntity> _new;
+
+        public ExpressionInstanciator()
+        {
+            Expression<Func<TEntity>> NewExpression = () => new TEntity();
+            _new = NewExpression.Compile();
+        }
+        public TEntity InstanciateNew(ICandidate<TEntity> candidate) => _new();
+    }
+
+    //https://blogs.msdn.microsoft.com/seteplia/2017/02/01/dissecting-the-new-constraint-in-c-a-perfect-example-of-a-leaky-abstraction/
+    public class ILInstanciator<TEntity> : IInstanciator<TEntity>
+        where TEntity : class, new()
+    {
+        private readonly Func<TEntity> _new;
+
+        public ILInstanciator()
+        {
+            var type = typeof(TEntity);
+            var constructor = Expression.New(type).Constructor;
+
+            var method = new DynamicMethod("constructor", type, new Type[0], typeof(IEntityBase).Module, true);
+            var ilGen = method.GetILGenerator();
+
+            if (constructor == null) // value types
+            {
+                var temp = ilGen.DeclareLocal(type);
+                ilGen.Emit(OpCodes.Ldloca, temp);
+                ilGen.Emit(OpCodes.Initobj, type);
+                ilGen.Emit(OpCodes.Ldloc, temp);
+            }
+            else
+            {
+                ilGen.Emit(OpCodes.Newobj, constructor);
+            }
+
+            ilGen.Emit(OpCodes.Ret);
+
+            _new = (Func<TEntity>)method.CreateDelegate(typeof(Func<TEntity>));
+        }
+
+        public TEntity InstanciateNew(ICandidate<TEntity> candidate) => _new();
+    }
+
+    [MemoryDiagnoser]
+    public class Instanciators
+    {
+        class User
+        {
+            public Guid Id { get; set; }
+        }
+
+        private readonly DefaultInstanciator<User> _default = new DefaultInstanciator<User>();
+        private readonly ExpressionInstanciator<User> _expression = new ExpressionInstanciator<User>();
+        private readonly ILInstanciator<User> _il = new ILInstanciator<User>();
+
+        private static Func<User> Function => () => new User();
+
+        [Benchmark]
+        public void UserFactory()
+        {
+            Function();
+        }
+
+        [Benchmark(Baseline = true)]
+        public void DefaultInstanciator()
+        {
+            _default.InstanciateNew(null);
+        }
+
+        [Benchmark]
+        public void ExpressionInstanciator()
+        {
+            _expression.InstanciateNew(null);
+        }
+
+        [Benchmark]
+        public void ILInstanciator()
+        {
+            _il.InstanciateNew(null);
+        }
+    }
+}

--- a/benchmarks/Serialization/Program.cs
+++ b/benchmarks/Serialization/Program.cs
@@ -7,7 +7,7 @@ namespace Rdd.Benchmarks
     {
         static void Main(string[] args)
         {
-            var summary = BenchmarkRunner.Run<RddVsNewtonsoft>();
+            var summary = BenchmarkRunner.Run<Instanciators>();
             Console.ReadLine();
         }
     }

--- a/benchmarks/Serialization/RddVsNewtonsoft.cs
+++ b/benchmarks/Serialization/RddVsNewtonsoft.cs
@@ -30,7 +30,6 @@ namespace Rdd.Benchmarks
             public List<Other> Properties { get; set; }
             public string Token { get; set; }
             public string Name { get; set; }
-            public Culture Culture { get; set; }
         }
 
         class Other
@@ -46,11 +45,10 @@ namespace Rdd.Benchmarks
 
             var services = new ServiceCollection();
             var builder = new RddBuilder(services);
-            builder.AddRddSerialization();
 
             _servicesProvider = services.BuildServiceProvider();
             _serializer = _servicesProvider.GetService<ISerializerProvider>();
-            _fields = new ExpressionParser().ParseTree(typeof(User), "id,birthday,properties[id,name],token,name,culture");
+            _fields = new ExpressionParser().ParseTree(typeof(User), "id,birthday,properties[id,name],token,name");
             _jsonSerializer = JsonSerializer.CreateDefault();
 
             _writer = StreamWriter.Null;

--- a/src/Rdd.Domain/Models/DefaultInstanciator.cs
+++ b/src/Rdd.Domain/Models/DefaultInstanciator.cs
@@ -1,8 +1,19 @@
-﻿namespace Rdd.Domain.Models
+﻿using System;
+using System.Linq.Expressions;
+
+namespace Rdd.Domain.Models
 {
     public class DefaultInstanciator<TEntity> : IInstanciator<TEntity>
         where TEntity : class, new()
     {
-        public TEntity InstanciateNew(ICandidate<TEntity> candidate) => new TEntity();
+        private readonly Func<TEntity> _new;
+
+        public DefaultInstanciator()
+        {
+            Expression<Func<TEntity>> NewExpression = () => new TEntity();
+            _new = NewExpression.Compile();
+        }
+
+        public TEntity InstanciateNew(ICandidate<TEntity> candidate) => _new();// new TEntity() is 10X slower
     }
 }


### PR DESCRIPTION
After reading this
https://blogs.msdn.microsoft.com/seteplia/2017/02/01/dissecting-the-new-constraint-in-c-a-perfect-example-of-a-leaky-abstraction/

I gave a try at IL for RDD instanciator.
"Unfortunately", aspnetcore reflection and expression in general are much more performant than .net framework.

So the expression form is better/similar than IL, but way clearer.
Anyway, I proposed a different instanciator 10X more performant. The expression compilation cost is cashed only once since this component is registered as a singleton.


Method |      Mean |     Error |    StdDev | Scaled |  Gen 0 | Allocated |
----------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
Lambda | 11.279 ns | 0.1079 ns | 0.0901 ns |   0.17 | 0.0102 |      32 B |
DefaultInstanciator | 64.811 ns | 0.7400 ns | 0.6560 ns |   1.00 | 0.0101 |      32 B |
ExpressionInstanciator |  6.791 ns | 0.1733 ns | 0.1621 ns |   0.10 | 0.0102 |      32 B |
ILInstanciator |  8.325 ns | 0.2062 ns | 0.2375 ns |   0.13 | 0.0102 |      32 B |