### PR TITLE
IUrlProvider : adds test for new endpoint routing support

### DIFF
--- a/test/Rdd.Web.Tests/ApiExplorerTests.cs
+++ b/test/Rdd.Web.Tests/ApiExplorerTests.cs
@@ -13,7 +13,8 @@ namespace Rdd.Web.Tests
         [Fact]
         public void ApiExplorer()
         {
-            var host = Startup.BuildWebHost(null).Build();
+            var host = HostBuilder.FromStartup<Startup>().Build();
+
             var apiExplorer = host.Services.GetRequiredService<IApiDescriptionGroupCollectionProvider>();
 
             //les items contient toutes les routes de tous les controllers (userweb, exchangerate, openexchangerate, ExchangeRate3Controller)

--- a/test/Rdd.Web.Tests/ExceptionIntegrationTest.cs
+++ b/test/Rdd.Web.Tests/ExceptionIntegrationTest.cs
@@ -22,7 +22,7 @@ namespace Rdd.Web.Tests
 
         private void SetupServer(Action<IServiceCollection> configureServices = null)
         {
-            var host = Startup.BuildWebHost(null);
+            var host = HostBuilder.FromStartup<Startup>();
             if (configureServices != null)
             {
                 host.ConfigureServices(configureServices);

--- a/test/Rdd.Web.Tests/ExchangeRateIntegrationTest.cs
+++ b/test/Rdd.Web.Tests/ExchangeRateIntegrationTest.cs
@@ -16,7 +16,7 @@ namespace Rdd.Web.Tests
 
         public ExchangeRateIntegrationTest()
         {
-            var host = Startup.BuildWebHost(null);
+            var host = HostBuilder.FromStartup<Startup>();
             host.ConfigureServices(c => { });
             _server = new TestServer(host);
             _client = _server.CreateClient();

--- a/test/Rdd.Web.Tests/Serialization/UrlProviderTests.cs
+++ b/test/Rdd.Web.Tests/Serialization/UrlProviderTests.cs
@@ -109,7 +109,18 @@ namespace Rdd.Web.Tests.Serialization
         [Fact]
         public void RealUrls()
         {
-            var host = Startup.BuildWebHost(null).Build();
+            var host = HostBuilder.FromStartup<Startup>().Build(); 
+            var urlProvider = host.Services.GetRequiredService<IUrlProvider>();
+
+            var entity = new ExchangeRate { Id = 123 };
+            var result = urlProvider.GetEntityApiUri(entity);
+            Assert.Equal("https://mon.domain.com/ExchangeRates/123", result.ToString());
+        }
+
+        [Fact]
+        public void RealUrlsAspnet22()
+        {
+            var host = HostBuilder.FromStartup<StartupMvc22>().Build();
             var urlProvider = host.Services.GetRequiredService<IUrlProvider>();
 
             var entity = new ExchangeRate { Id = 123 };

--- a/test/Rdd.Web.Tests/ServerMock/Startup.cs
+++ b/test/Rdd.Web.Tests/ServerMock/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,8 +12,6 @@ namespace Rdd.Web.Tests.ServerMock
 {
     public class Startup
     {
-        public static IWebHostBuilder BuildWebHost(string[] args) => WebHost.CreateDefaultBuilder(args).UseStartup<Startup>();
-
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -33,9 +32,14 @@ namespace Rdd.Web.Tests.ServerMock
                 })
                 .WithDefaultRights(RightDefaultMode.Open);
 
-            services.AddMvc();
+            SetupMvc(services);
 
             services.AddLogging();
+        }
+
+        protected virtual void SetupMvc(IServiceCollection services)
+        {
+            services.AddMvc();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -68,6 +72,29 @@ namespace Rdd.Web.Tests.ServerMock
                     template: "{controller}/{action}/{id?}",
                     defaults: new { controller = "Ping", action = "Status" });
             });
+        }
+    }
+
+    public static class HostBuilder
+    {
+        public static IWebHostBuilder FromStartup<TStartup>()
+            where TStartup : Startup
+            => FromStartup<TStartup>(null);
+
+        public static IWebHostBuilder FromStartup<TStartup>(string[] args)
+            where TStartup : Startup
+            => WebHost.CreateDefaultBuilder(args).UseStartup<TStartup>();
+    }
+
+    public class StartupMvc22 : Startup
+    {
+        public StartupMvc22(IConfiguration configuration) : base(configuration) { }
+
+        protected override void SetupMvc(IServiceCollection services)
+        {
+            services
+                .AddMvc(options => options.EnableEndpointRouting = false)
+                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
         }
     }
 }


### PR DESCRIPTION
adds test to validate the [new Endpoint routing](https://docs.microsoft.com/fr-fr/aspnet/core/fundamentals/routing?view=aspnetcore-2.2#differences-from-earlier-versions-of-routing) support