### PR TITLE
MOD : Apply AsNoTracking by default on Get web request.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Futur release
+#Futur release
+## Breaking changes
+ - **Modification**: On GET requests, Ef tracker is desactivated.
+# 3.0.0
 ## Breaking changes
  - **Removed**: `ReadOnlyRepository.CountAsync()` -> Use `ReadOnlyRepository.CountAsync(Query<T>)` instead
  - **Modification**: Rename protected method `ReadOnlyRepository.CountEntities()` ->`ReadOnlyRepository.CountEntitiesAsync()`.

--- a/src/Rdd.Domain/Models/Querying/Options.cs
+++ b/src/Rdd.Domain/Models/Querying/Options.cs
@@ -2,16 +2,19 @@
 {
     public class Options
     {
-        public bool NeedCount { get; set; }
+        public bool NeedsCount { get; set; }
 
-        public bool NeedEnumeration { get; set; }
+        public bool NeedsEnumeration { get; set; }
 
-        public bool CheckRights { get; set; }
+        public bool ChecksRights { get; set; }
+
+        public bool NeedsDataTracking { get; set; }
 
         public Options()
         {
-            NeedEnumeration = true;
-            CheckRights = true;
+            NeedsEnumeration = true;
+            ChecksRights = true;
+            NeedsDataTracking = true;
         }
     }
 }

--- a/src/Rdd.Domain/Models/ReadOnlyRestCollection.cs
+++ b/src/Rdd.Domain/Models/ReadOnlyRestCollection.cs
@@ -17,13 +17,7 @@ namespace Rdd.Domain.Models
 
         protected IReadOnlyRepository<TEntity> Repository { get; set; }
 
-        public Task<bool> AnyAsync(Query<TEntity> query)
-        {
-            query.Options.NeedEnumeration = false;
-            query.Options.NeedCount = true;
-
-            return Repository.AnyAsync(query);
-        }
+        public Task<bool> AnyAsync(Query<TEntity> query) => Repository.AnyAsync(query);
 
         public virtual async Task<ISelection<TEntity>> GetAsync(Query<TEntity> query)
         {
@@ -31,13 +25,13 @@ namespace Rdd.Domain.Models
             IEnumerable<TEntity> items = new HashSet<TEntity>();
 
             //Dans de rares cas on veut seulement le count des entités
-            if (query.Options.NeedCount && !query.Options.NeedEnumeration)
+            if (query.Options.NeedsCount && !query.Options.NeedsEnumeration)
             {
                 count = await Repository.CountAsync(query);
             }
 
             //En général on veut une énumération des entités
-            if (query.Options.NeedEnumeration)
+            if (query.Options.NeedsEnumeration)
             {
                 items = await Repository.GetAsync(query);
 

--- a/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
+++ b/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
@@ -25,8 +25,9 @@ namespace Rdd.Infra.Storage
 
         public virtual Task<int> CountAsync(Query<TEntity> query)
         {
-            var entities = Set();
-            if (query.Options.CheckRights)
+            IQueryable<TEntity> entities = Set();
+
+            if (query.Options.ChecksRights)
             {
                 entities = ApplyRights(entities, query);
             }
@@ -41,9 +42,11 @@ namespace Rdd.Infra.Storage
 
         public virtual Task<IEnumerable<TEntity>> GetAsync(Query<TEntity> query)
         {
-            var entities = Set();
+            IQueryable<TEntity> entities = Set();
 
-            if (query.Options.CheckRights)
+            entities = ApplyDataTracking(entities, query);
+
+            if (query.Options.ChecksRights)
             {
                 entities = ApplyRights(entities, query);
             }
@@ -69,7 +72,8 @@ namespace Rdd.Infra.Storage
         public Task<bool> AnyAsync(Query<TEntity> query)
         {
             IQueryable<TEntity> entities = Set();
-            if (query.Options.CheckRights)
+
+            if (query.Options.ChecksRights)
             {
                 entities = ApplyRights(entities, query);
             }
@@ -123,6 +127,11 @@ namespace Rdd.Infra.Storage
             }
 
             return entities;
+        }
+
+        protected virtual IQueryable<TEntity> ApplyDataTracking(IQueryable<TEntity> entities, Query<TEntity> query)
+        {
+            return query.Options.NeedsDataTracking ? entities : entities.AsNoTracking();
         }
     }
 }

--- a/src/Rdd.Web/Querying/QueryParser.cs
+++ b/src/Rdd.Web/Querying/QueryParser.cs
@@ -42,8 +42,13 @@ namespace Rdd.Web.Querying
 
             if (query.Fields.Contains((ISelection c) => c.Count))
             {
-                query.Options.NeedCount = true;
-                query.Options.NeedEnumeration = query.Fields.Children.Count != 1;
+                query.Options.NeedsCount = true;
+                query.Options.NeedsEnumeration = query.Fields.Children.Count != 1;
+            }
+
+            if (query.Verb == HttpVerbs.Get)
+            {
+                query.Options.NeedsDataTracking = false;
             }
 
             return query;

--- a/test/Rdd.Domain.Tests/AppControllerTests.cs
+++ b/test/Rdd.Domain.Tests/AppControllerTests.cs
@@ -35,7 +35,7 @@ namespace Rdd.Domain.Tests
             var users = new UsersCollectionWithHardcodedGetById(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
             var controller = new UsersAppController(_fixture.InMemoryStorage, users);
             var query = new Query<User>();
-            query.Options.CheckRights = false;
+            query.Options.ChecksRights = false;
             var id = Guid.NewGuid();
             var candidate = _parser.Parse<User, Guid>($@"{{ ""id"": ""{id}"" }}");
 
@@ -50,7 +50,7 @@ namespace Rdd.Domain.Tests
             var users = new UsersCollectionWithHardcodedGetById(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
             var controller = new UsersAppController(_fixture.InMemoryStorage, users);
             var query = new Query<User>();
-            query.Options.CheckRights = false;
+            query.Options.ChecksRights = false;
             var id1 = Guid.NewGuid();
             var id2 = Guid.NewGuid();
             var candidate1 = _parser.Parse<User, Guid>($@"{{ ""id"": ""{id1}"" }}");
@@ -68,7 +68,7 @@ namespace Rdd.Domain.Tests
             var users = new UsersCollectionWithHardcodedGetById(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
             var controller = new UsersAppController(_fixture.InMemoryStorage, users);
             var query = new Query<User>();
-            query.Options.CheckRights = false;
+            query.Options.ChecksRights = false;
             var id = Guid.NewGuid();
             var candidate = _parser.Parse<User, Guid>($@"{{ ""id"": ""{id}"" }}");
 

--- a/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
+++ b/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
@@ -77,7 +77,7 @@ namespace Rdd.Domain.Tests
         {
             var users = new UsersCollection(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
             var query = new Query<User>();
-            query.Options.CheckRights = false;
+            query.Options.ChecksRights = false;
 
             var candidate = _parser.Parse<User, Guid>($@"{{ ""id"": ""{Guid.NewGuid()}"" }}");
             await users.CreateAsync(candidate, query);
@@ -100,7 +100,7 @@ namespace Rdd.Domain.Tests
             var repo = new Repository<UserWithParameters>(_fixture.InMemoryStorage, new OpenRightExpressionsHelper<UserWithParameters>());
             var users = new UsersCollectionWithParameters(repo, _fixture.PatcherProvider, new InstanciatorImplementation());
             var query = new Query<UserWithParameters>();
-            query.Options.CheckRights = false;
+            query.Options.ChecksRights = false;
 
             var candidate = _parser.Parse<UserWithParameters, int>(@"{ ""id"": 3, ""name"": ""John"" }");
             var result = await users.CreateAsync(candidate, query);
@@ -115,7 +115,7 @@ namespace Rdd.Domain.Tests
             var user = new User { Id = id };
             var users = new UsersCollection(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
             var query = new Query<User>();
-            query.Options.CheckRights = false;
+            query.Options.ChecksRights = false;
 
             _fixture.InMemoryStorage.Add(user);
             await _fixture.InMemoryStorage.SaveChangesAsync();
@@ -132,7 +132,7 @@ namespace Rdd.Domain.Tests
             var user = new User { Id = id, Name = "Name", Salary = 1, TwitterUri = new Uri("https://twitter.com") };
             var users = new UsersCollection(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
             var query = new Query<User>();
-            query.Options.CheckRights = false;
+            query.Options.ChecksRights = false;
 
             _fixture.InMemoryStorage.Add(user);
             await _fixture.InMemoryStorage.SaveChangesAsync();
@@ -165,7 +165,7 @@ namespace Rdd.Domain.Tests
 
             var users = new RestCollection<User, Guid>(_fixture.UsersRepo, new OverrideObjectPatcher<User>(_fixture.PatcherProvider), _fixture.Instanciator);
             var query = new Query<User>();
-            query.Options.CheckRights = false;
+            query.Options.ChecksRights = false;
 
             var updated = await users.UpdateByIdAsync(id, _parser.Parse<User, Guid>(JsonConvert.SerializeObject(user)), query);
 
@@ -179,7 +179,7 @@ namespace Rdd.Domain.Tests
             var user = new User { Id = id, Name = "Name", Salary = 1, TwitterUri = new Uri("https://twitter.com") };
             var users = new UsersCollection(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
             var query = new Query<User>();
-            query.Options.CheckRights = false;
+            query.Options.ChecksRights = false;
 
             _fixture.InMemoryStorage.Add(user);
             await _fixture.InMemoryStorage.SaveChangesAsync();

--- a/test/Rdd.Infra.Tests/CollectionTests.cs
+++ b/test/Rdd.Infra.Tests/CollectionTests.cs
@@ -128,7 +128,7 @@ namespace Rdd.Infra.Tests
 
                 //Act
                 var query = new Query<User>(u => u.Id == user.Id);
-                query.Options.CheckRights = true;
+                query.Options.ChecksRights = true;
                 var exist = (await collection.AnyAsync(query));
 
                 //Assert

--- a/test/Rdd.Web.Tests/Models/UserWebController.cs
+++ b/test/Rdd.Web.Tests/Models/UserWebController.cs
@@ -18,7 +18,7 @@ namespace Rdd.Web.Tests.Models
         public async Task<IEnumerable<IUser>> GetEnumerableAsync()
         {
             var query = new Query<IUser>();
-            query.Options.CheckRights = false; //Don't care about rights check
+            query.Options.ChecksRights = false; //Don't care about rights check
 
             return (await AppController.GetAsync(query)).Items;
         }

--- a/test/Rdd.Web.Tests/OptionsParserTests.cs
+++ b/test/Rdd.Web.Tests/OptionsParserTests.cs
@@ -14,8 +14,8 @@ namespace Rdd.Web.Tests
 
             var query = QueryParserHelper.GetQueryParser<User>().Parse(request, true);
 
-            Assert.True(query.Options.NeedCount);
-            Assert.False(query.Options.NeedEnumeration);
+            Assert.True(query.Options.NeedsCount);
+            Assert.False(query.Options.NeedsEnumeration);
         }
     }
 }

--- a/test/Rdd.Web.Tests/QueryParserTests.cs
+++ b/test/Rdd.Web.Tests/QueryParserTests.cs
@@ -21,8 +21,8 @@ namespace Rdd.Web.Tests
             var request = HttpVerbs.Get.NewRequest(("fields", "collection.count")); 
             var query = QueryParserHelper.GetQueryParser<User>().Parse(request, true);
 
-            Assert.True(query.Options.NeedCount);
-            Assert.False(query.Options.NeedEnumeration);
+            Assert.True(query.Options.NeedsCount);
+            Assert.False(query.Options.NeedsEnumeration);
         }
 
         [Fact]


### PR DESCRIPTION
This change in default behavior is only applied on Query generated by the QueryParser, which implies this comes from the web layer.
The rest of the default behavior is not changed.

Great perf gain expected on memory.