### PR TITLE
error management centralisation : remove middleware from RestDrivenDomain

### DIFF
--- a/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -113,13 +113,21 @@ namespace Rdd.Web.Helpers
         /// <summary>
         /// Register Rdd middleware in the pipeline request BEFORE UseMVC
         /// </summary>
-        /// <param name="app"></param>
-        /// <returns></returns>
-        public static IApplicationBuilder UseRdd(this IApplicationBuilder app)
+        public static IApplicationBuilder UseRdd(this IApplicationBuilder app, RddCompatibilityVersion rddCompatibilityVersion = RddCompatibilityVersion.Version_3_2)
         {
-            return app
-                .UseMiddleware<EnableRequestRewindMiddleware>()
-                .UseMiddleware<HttpStatusCodeExceptionMiddleware>();
+
+            app.UseMiddleware<EnableRequestRewindMiddleware>();
+            if (rddCompatibilityVersion < RddCompatibilityVersion.Version_3_3)
+            {
+                app.UseMiddleware<HttpStatusCodeExceptionMiddleware>();
+            }
+            return app;
+        }
+
+        public enum RddCompatibilityVersion
+        {
+            Version_3_2 = 1,
+            Version_3_3,
         }
     }
 }

--- a/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -123,11 +123,11 @@ namespace Rdd.Web.Helpers
             }
             return app;
         }
+    }
 
-        public enum RddCompatibilityVersion
-        {
-            Version_3_2 = 1,
-            Version_3_3,
-        }
+    public enum RddCompatibilityVersion
+    {
+        Version_3_2 = 1,
+        Version_3_3,
     }
 }

--- a/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -127,7 +127,7 @@ namespace Rdd.Web.Helpers
 
     public enum RddCompatibilityVersion
     {
-        Version_3_2 = 1,
+        Version_3_2,
         Version_3_3,
     }
 }


### PR DESCRIPTION
Errors will be managed either by standard aspnet core middleware, or by custom handlers outside RestDrivenDomain.
Little breaking change for endusers