### PR TITLE
try fix sonar

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,9 +43,9 @@ before_build:
 - dotnet restore
 - cmd: >-
     IF "%APPVEYOR_PULL_REQUEST_NUMBER%"=="" (
-    dotnet sonarscanner begin /k:"RestDrivenDomain" /d:"sonar.analysis.mode=publish" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.organization=luccaintegration-github" /d:"sonar.login=%SONAR_TOKEN%" /d:sonar.cs.opencover.reportsPaths="coverage-opencover.xml"
+    dotnet sonarscanner begin /k:"RestDrivenDomain" /d:"sonar.analysis.mode=publish" /d:"sonar.host.url=https://sonarcloud.io" /o:luccaintegration-github /d:"sonar.login=%SONAR_TOKEN%" /d:sonar.cs.opencover.reportsPaths="coverage-opencover.xml"
     ) ELSE (
-    dotnet sonarscanner begin /k:"RestDrivenDomain" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.organization=luccaintegration-github" /d:"sonar.login=%SONAR_TOKEN%" /d:"sonar.github.oauth=%GITHUB_ACCESS_TOKEN%" /d:"sonar.pullrequest.provider=github" /d:"sonar.pullrequest.branch=%APPVEYOR_REPO_BRANCH%" /d:"sonar.pullrequest.key=%APPVEYOR_PULL_REQUEST_NUMBER%" /d:"sonar.pullrequest.github.repository=LuccaSA/RestDrivenDomain" /d:"sonar.pullrequest.github.endpoint=https://api.github.com"
+    dotnet sonarscanner begin /k:"RestDrivenDomain" /d:"sonar.host.url=https://sonarcloud.io" /o:luccaintegration-github /d:"sonar.login=%SONAR_TOKEN%" /d:"sonar.github.oauth=%GITHUB_ACCESS_TOKEN%" /d:"sonar.pullrequest.provider=github" /d:"sonar.pullrequest.branch=%APPVEYOR_REPO_BRANCH%" /d:"sonar.pullrequest.key=%APPVEYOR_PULL_REQUEST_NUMBER%" /d:"sonar.pullrequest.github.repository=LuccaSA/RestDrivenDomain" /d:"sonar.pullrequest.github.endpoint=https://api.github.com"
     )
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ notifications:
   channel: '#build-opensource'
 
 install:
-  - choco install dotnetcore-sdk --version 2.1.500
+  - choco install dotnetcore-sdk --version 2.2.104
   - ps: wget "https://raw.githubusercontent.com/rducom/ALM/master/build/ComputeVersion.ps1" -outfile "ComputeVersion.ps1"
   - ps: . .\ComputeVersion.ps1
   - ps: $version = Compute "src\Rdd.Web\Rdd.Web.csproj" $env:APPVEYOR_BUILD_NUMBER $env:APPVEYOR_REPO_TAG $env:APPVEYOR_PULL_REQUEST_NUMBER


### PR DESCRIPTION
breaking change in the last sonar-scanner version : 
> Please use the parameter prefix '/o:' to define the organization of the SonarQube project instead of injecting this organization with the help of the 'sonar.organization' property.

problem seen here : https://github.com/LuccaSA/RestDrivenDomain/pull/310
Also, this PR will fix the netsdk version to the last 2.2.2. Let me know if you want a separate PR