### PR TITLE
MOD : ReadOnlyRepository.ApplyRights becomes async

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 #Futur release
 ## Breaking changes
+ - **Modification**: `IRightExpressionsHelper.GetFilter` -> `IRightExpressionsHelper.GetFilterAsync`
+ - **Modification**: `ReadOnlyRepository.ApplyRights` -> `ReadOnlyRepository.ApplyRightsAsync`
+# 3.1.0
+## Breaking changes
  - **Modification**: On GET requests, Ef tracker is desactivated.
 ## New features
  - **Added**: ``ReadOnlyMappedWebController``. Allow the use of DTO on the Web layer.

--- a/src/Rdd.Domain/Rights/ClosedRightExpressionsHelper.cs
+++ b/src/Rdd.Domain/Rights/ClosedRightExpressionsHelper.cs
@@ -1,12 +1,13 @@
 ﻿using Rdd.Domain.Models.Querying;
 using System;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace Rdd.Domain.Rights
 {
     public class ClosedRightExpressionsHelper<T> : IRightExpressionsHelper<T>
          where T : class
     {
-        public Expression<Func<T, bool>> GetFilter(Query<T> query) => t => false;
+        public Task<Expression<Func<T, bool>>> GetFilterAsync(Query<T> query) => Task.FromResult<Expression<Func<T, bool>>>(t => false);
     }
 }

--- a/src/Rdd.Domain/Rights/IRightExpressionsHelper.cs
+++ b/src/Rdd.Domain/Rights/IRightExpressionsHelper.cs
@@ -1,12 +1,13 @@
 ﻿using Rdd.Domain.Models.Querying;
 using System;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace Rdd.Domain.Rights
 {
     public interface IRightExpressionsHelper<T>
          where T : class
     {
-        Expression<Func<T, bool>> GetFilter(Query<T> query);
+        Task<Expression<Func<T, bool>>> GetFilterAsync(Query<T> query);
     }
 }

--- a/src/Rdd.Domain/Rights/OpenRightExpressionsHelper.cs
+++ b/src/Rdd.Domain/Rights/OpenRightExpressionsHelper.cs
@@ -1,12 +1,13 @@
 ﻿using Rdd.Domain.Models.Querying;
 using System;
 using System.Linq.Expressions;
+using System.Threading.Tasks;
 
 namespace Rdd.Domain.Rights
 {
     public class OpenRightExpressionsHelper<T> : IRightExpressionsHelper<T>
          where T : class
     {
-        public Expression<Func<T, bool>> GetFilter(Query<T> query) => t => true;
+        public Task<Expression<Func<T, bool>>> GetFilterAsync(Query<T> query) => Task.FromResult<Expression<Func<T, bool>>>(t => true);
     }
 }

--- a/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
+++ b/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
@@ -23,24 +23,24 @@ namespace Rdd.Infra.Storage
             RightExpressionsHelper = rightExpressionsHelper;
         }
 
-        public virtual Task<int> CountAsync(Query<TEntity> query)
+        public virtual async Task<int> CountAsync(Query<TEntity> query)
         {
             IQueryable<TEntity> entities = Set();
 
             if (query.Options.ChecksRights)
             {
-                entities = ApplyRights(entities, query);
+                entities = await ApplyRightsAsync(entities, query);
             }
 
             entities = ApplyFilters(entities, query);
 
-            return CountEntitiesAsync(entities);
+            return await CountEntitiesAsync(entities);
         }
 
         protected virtual Task<int> CountEntitiesAsync(IQueryable<TEntity> entities)
             => StorageService.CountAsync(entities);
 
-        public virtual Task<IEnumerable<TEntity>> GetAsync(Query<TEntity> query)
+        public virtual async Task<IEnumerable<TEntity>> GetAsync(Query<TEntity> query)
         {
             IQueryable<TEntity> entities = Set();
 
@@ -48,7 +48,7 @@ namespace Rdd.Infra.Storage
 
             if (query.Options.ChecksRights)
             {
-                entities = ApplyRights(entities, query);
+                entities = await ApplyRightsAsync(entities, query);
             }
 
             entities = ApplyFilters(entities, query);
@@ -61,7 +61,7 @@ namespace Rdd.Infra.Storage
 
             entities = ApplyIncludes(entities, query);
 
-            return StorageService.EnumerateEntitiesAsync(entities);
+            return await StorageService.EnumerateEntitiesAsync(entities);
         }
 
         public virtual Task<IEnumerable<TEntity>> PrepareAsync(IEnumerable<TEntity> entities, Query<TEntity> query)
@@ -69,25 +69,26 @@ namespace Rdd.Infra.Storage
             return Task.FromResult(entities);
         }
 
-        public Task<bool> AnyAsync(Query<TEntity> query)
+        public async Task<bool> AnyAsync(Query<TEntity> query)
         {
             IQueryable<TEntity> entities = Set();
 
             if (query.Options.ChecksRights)
             {
-                entities = ApplyRights(entities, query);
+                entities = await ApplyRightsAsync(entities, query);
             }
 
             entities = ApplyFilters(entities, query);
 
-            return StorageService.AnyAsync(entities);
+            return await StorageService.AnyAsync(entities);
         }
 
         protected virtual IQueryable<TEntity> Set() => StorageService.Set<TEntity>();
 
-        protected virtual IQueryable<TEntity> ApplyRights(IQueryable<TEntity> entities, Query<TEntity> query)
+        protected virtual async Task<IQueryable<TEntity>> ApplyRightsAsync(IQueryable<TEntity> entities, Query<TEntity> query)
         {
-            return entities.Where(RightExpressionsHelper.GetFilter(query));
+            var filter = await RightExpressionsHelper.GetFilterAsync(query);
+            return entities.Where(filter);
         }
 
         protected virtual IQueryable<TEntity> ApplyFilters(IQueryable<TEntity> entities, Query<TEntity> query)

--- a/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
+++ b/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
@@ -59,7 +59,7 @@ namespace Rdd.Domain.Tests
         {
             Expression<Func<User, bool>> trueFilter = t => true;
             var rightService = new Mock<IRightExpressionsHelper<User>>();
-            rightService.Setup(s => s.GetFilter(It.IsAny<Query<User>>())).Returns(trueFilter);
+            rightService.Setup(s => s.GetFilterAsync(It.IsAny<Query<User>>())).Returns(Task.FromResult(trueFilter));
 
             var id = Guid.NewGuid();
             var repo = new Repository<User>(_fixture.InMemoryStorage, rightService.Object);

--- a/test/Rdd.Domain.Tests/Models/OpenRepository.cs
+++ b/test/Rdd.Domain.Tests/Models/OpenRepository.cs
@@ -2,6 +2,7 @@
 using Rdd.Domain.Rights;
 using Rdd.Infra.Storage;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Rdd.Domain.Tests.Models
 {
@@ -11,14 +12,14 @@ namespace Rdd.Domain.Tests.Models
         public OpenRepository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightsService)
         : base(storageService, rightsService) { }
 
-        protected override IQueryable<TEntity> ApplyRights(IQueryable<TEntity> entities, Query<TEntity> query)
+        protected override async Task<IQueryable<TEntity>> ApplyRightsAsync(IQueryable<TEntity> entities, Query<TEntity> query)
         {
             if (query.Verb == Helpers.HttpVerbs.Get)
             {
                 return entities;
             }
 
-            return base.ApplyRights(entities, query);
+            return await base.ApplyRightsAsync(entities, query);
         }
     }
 }

--- a/test/Rdd.Domain.Tests/RightExpressionsHelperTests.cs
+++ b/test/Rdd.Domain.Tests/RightExpressionsHelperTests.cs
@@ -1,5 +1,6 @@
 ﻿using Rdd.Domain.Rights;
 using Rdd.Domain.Tests.Models;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Rdd.Domain.Tests
@@ -7,12 +8,12 @@ namespace Rdd.Domain.Tests
     public class RightExpressionsHelperTests
     {
         [Fact]
-        public void RightExpressionsHelper()
+        public async Task RightExpressionsHelper()
         {
-            var filter = new OpenRightExpressionsHelper<User>().GetFilter(new Domain.Models.Querying.Query<User> { Verb = Helpers.HttpVerbs.Get });
+            var filter = await new OpenRightExpressionsHelper<User>().GetFilterAsync(new Domain.Models.Querying.Query<User> { Verb = Helpers.HttpVerbs.Get });
             Assert.True(filter.Compile()(null));
 
-            filter = new ClosedRightExpressionsHelper<User>().GetFilter(new Domain.Models.Querying.Query<User> { Verb = Helpers.HttpVerbs.Get });
+            filter = await new ClosedRightExpressionsHelper<User>().GetFilterAsync(new Domain.Models.Querying.Query<User> { Verb = Helpers.HttpVerbs.Get });
             Assert.False(filter.Compile()(null));
         }
     }


### PR DESCRIPTION
This is necessary in order to correctly handle async rights applications, as those may require web call or db request.

This breaks two apis, in changelog.

This should be in a 4.0, but if you're comfortable with it, a 3.2 would do with me.