### PR TITLE
[UPD] prevent to override several methods doing the same thing.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,16 @@
 #Futur release
+ - **Modification**: `AppController.CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query)` -> not overridable anymore
+ - **Removed**: `AppController.CreateAsync(IEnumerable<TEntity> entities)`
+ - **Modification**: `AppController.UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query)` -> not overridable anymore
+ - **Modification**: `AppController.DeleteByIdAsync(TKey id)` -> not overridable anymore
+ - **Modification**: `RestCollection.Add(TEntity entity)` -> not overridable anymore 
+ - **Modification**: `RestCollection.CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null)` -> removing unused query parameter and not overridable anymore
+ - **Modification**: `RestCollection.CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query = null)` -> removing unused query parameter and not overridable anymore
+ - **Modification**: `RestCollection.UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null)` -> removing unused query parameter and not overridable anymore
+ - **Modification**: `RestCollection.DeleteByIdAsync(TKey id)` -> not overridable anymore
+ - **Modification**: `Repository.Add(TEntity entity)` -> not overridable anymore
+ 
+ 
 # 3.2.0
 ## Breaking changes
  - **Modification**: `IRightExpressionsHelper.GetFilter` -> `IRightExpressionsHelper.GetFilterAsync`

--- a/src/Rdd.Application/Controllers/AppController.cs
+++ b/src/Rdd.Application/Controllers/AppController.cs
@@ -1,7 +1,9 @@
 ﻿using Rdd.Domain;
+using Rdd.Domain.Helpers;
 using Rdd.Domain.Models.Querying;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Rdd.Application.Controllers
@@ -29,32 +31,23 @@ namespace Rdd.Application.Controllers
             _unitOfWork = unitOfWork;
         }
 
-        public virtual async Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query)
+        public async Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query)
         {
-            var result = await Collection.CreateAsync(candidate, query);
-            await SaveChangesAsync();
-            return result;
+            var results = await CreateAsync(candidate.Yield(), query);
+            return results.First();
         }
 
         public virtual async Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query)
         {
-            var result = await Collection.CreateAsync(candidates, query);
+            var result = await Collection.CreateAsync(candidates);
             await SaveChangesAsync();
             return result;
         }
 
-        public virtual async Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<TEntity> entities)
+        public async Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query)
         {
-            var result = await Collection.CreateAsync(entities);
-            await SaveChangesAsync();
-            return result;
-        }
-
-        public virtual async Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query)
-        {
-            var result = await Collection.UpdateByIdAsync(id, candidate, query);
-            await SaveChangesAsync();
-            return result;
+            var results = await UpdateByIdsAsync(new Dictionary<TKey, ICandidate<TEntity, TKey>> { { id, candidate } }, query);
+            return results.First();
         }
 
         public virtual async Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, ICandidate<TEntity, TKey>> candidatesByIds, Query<TEntity> query)
@@ -64,10 +57,9 @@ namespace Rdd.Application.Controllers
             return result;
         }
 
-        public virtual async Task DeleteByIdAsync(TKey id)
+        public Task DeleteByIdAsync(TKey id)
         {
-            await Collection.DeleteByIdAsync(id);
-            await SaveChangesAsync();
+            return DeleteByIdsAsync(id.Yield());
         }
 
         public virtual async Task DeleteByIdsAsync(IEnumerable<TKey> ids)

--- a/src/Rdd.Application/IAppController.cs
+++ b/src/Rdd.Application/IAppController.cs
@@ -12,7 +12,6 @@ namespace Rdd.Application
     {
         Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query);
         Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query);
-        Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<TEntity> entities);
         Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query);
         Task<IEnumerable<TEntity>> UpdateByIdsAsync(IDictionary<TKey, ICandidate<TEntity, TKey>> candidatesByIds, Query<TEntity> query);
 

--- a/src/Rdd.Domain/IRestCollection.cs
+++ b/src/Rdd.Domain/IRestCollection.cs
@@ -9,8 +9,8 @@ namespace Rdd.Domain
         where TEntity : class, IEntityBase<TKey>
         where TKey : IEquatable<TKey>
     {
-        Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null);
-        Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query = null);
+        Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate);
+        Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates);
         Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<TEntity> entities);
 
         Task<TEntity> UpdateByIdAsync(TKey id, ICandidate<TEntity, TKey> candidate, Query<TEntity> query = null);

--- a/src/Rdd.Infra/Storage/Repository.cs
+++ b/src/Rdd.Infra/Storage/Repository.cs
@@ -1,4 +1,5 @@
 ﻿using Rdd.Domain;
+using Rdd.Domain.Helpers;
 using Rdd.Domain.Rights;
 using System.Collections.Generic;
 
@@ -10,9 +11,9 @@ namespace Rdd.Infra.Storage
         public Repository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightExpressionsHelper)
             : base(storageService, rightExpressionsHelper) { }
 
-        public virtual void Add(TEntity entity)
+        public void Add(TEntity entity)
         {
-            StorageService.Add(entity);
+            StorageService.AddRange(entity.Yield());
         }
 
         public virtual void AddRange(IEnumerable<TEntity> entities)

--- a/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
+++ b/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
@@ -76,11 +76,8 @@ namespace Rdd.Domain.Tests
         public async Task Post_SHOULD_work_WHEN_InstantiateEntityIsNotOverridenAndEntityHasAParameterlessConstructor()
         {
             var users = new UsersCollection(_fixture.UsersRepo, _fixture.PatcherProvider, _fixture.Instanciator);
-            var query = new Query<User>();
-            query.Options.ChecksRights = false;
-
             var candidate = _parser.Parse<User, Guid>($@"{{ ""id"": ""{Guid.NewGuid()}"" }}");
-            await users.CreateAsync(candidate, query);
+            await users.CreateAsync(candidate);
         }
 
         private class InstanciatorImplementation : IInstanciator<UserWithParameters>
@@ -99,11 +96,8 @@ namespace Rdd.Domain.Tests
         {
             var repo = new Repository<UserWithParameters>(_fixture.InMemoryStorage, new OpenRightExpressionsHelper<UserWithParameters>());
             var users = new UsersCollectionWithParameters(repo, _fixture.PatcherProvider, new InstanciatorImplementation());
-            var query = new Query<UserWithParameters>();
-            query.Options.ChecksRights = false;
-
             var candidate = _parser.Parse<UserWithParameters, int>(@"{ ""id"": 3, ""name"": ""John"" }");
-            var result = await users.CreateAsync(candidate, query);
+            var result = await users.CreateAsync(candidate);
             Assert.Equal(3, result.Id);
             Assert.Equal("John", result.Name);
         }

--- a/test/Rdd.Web.Tests/Services/RddBuilderTests.cs
+++ b/test/Rdd.Web.Tests/Services/RddBuilderTests.cs
@@ -128,8 +128,8 @@ namespace Rdd.Web.Tests.Services
         {
             public Task<bool> AnyAsync(Query<Hierarchy> query) => throw new NotImplementedException();
 
-            public Task<Hierarchy> CreateAsync(ICandidate<Hierarchy, int> candidate, Query<Hierarchy> query = null) => throw new NotImplementedException();
-            public Task<IEnumerable<Hierarchy>> CreateAsync(IEnumerable<ICandidate<Hierarchy, int>> candidates, Query<Hierarchy> query = null) => throw new NotImplementedException();
+            public Task<Hierarchy> CreateAsync(ICandidate<Hierarchy, int> candidate) => throw new NotImplementedException();
+            public Task<IEnumerable<Hierarchy>> CreateAsync(IEnumerable<ICandidate<Hierarchy, int>> candidates) => throw new NotImplementedException();
             public Task<IEnumerable<Hierarchy>> CreateAsync(IEnumerable<Hierarchy> created) => throw new NotImplementedException();
 
             public Task DeleteByIdAsync(int id) => throw new NotImplementedException();


### PR DESCRIPTION
All Create, Delete or Update methods in application and domain layers could be overriden.
However, if we override the create method taking a single entity and not the one taking multiple entities we can get unexpected behavior.

With this PR, only one method of each type can be overriden.

Watch out for breaking changes.