### PR TITLE
ALT : alternative to rdd.repo.override.safe

### DIFF
--- a/src/Rdd.Application/Controllers/AppController.cs
+++ b/src/Rdd.Application/Controllers/AppController.cs
@@ -1,7 +1,9 @@
 ﻿using Rdd.Domain;
+using Rdd.Domain.Helpers;
 using Rdd.Domain.Models.Querying;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Rdd.Application.Controllers
@@ -29,11 +31,10 @@ namespace Rdd.Application.Controllers
             _unitOfWork = unitOfWork;
         }
 
-        public virtual async Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query)
+        public async Task<TEntity> CreateAsync(ICandidate<TEntity, TKey> candidate, Query<TEntity> query)
         {
-            var result = await Collection.CreateAsync(candidate, query);
-            await SaveChangesAsync();
-            return result;
+            var results = await CreateAsync(candidate.Yield(), query);
+            return results.First();
         }
 
         public virtual async Task<IEnumerable<TEntity>> CreateAsync(IEnumerable<ICandidate<TEntity, TKey>> candidates, Query<TEntity> query)


### PR DESCRIPTION
**DO NOT MERGE, ONLY HERE FOR ALTERNATIVE PROPOSITION**

This branch only targets the Create process (not the Update nor Delete).

It gives more flexibility to the Create process into the collection class, where you can override the CreateAsync of ONE entity and be confident it will be played when sending MANY entities, because the utility code resides inside :
- ForgeEntity, from a candidate or an entity, which is sync
- ValidateEntityAsync, which is async

All other methods are either not overridable, or overridable but only for mass-treatment purpose, not for changing the way you would forge or validate an entity