### PR TITLE
FIX : add constraint on rddJsonResult to prevent fiels type mismatch

### DIFF
--- a/src/Rdd.Web/Serialization/RddJsonResult.cs
+++ b/src/Rdd.Web/Serialization/RddJsonResult.cs
@@ -11,6 +11,7 @@ using Rdd.Web.Models;
 using Rdd.Web.Serialization.Providers;
 using System;
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Claims;
@@ -32,13 +33,19 @@ namespace Rdd.Web.Serialization
     {
         public IExpressionTree Fields { get; private set; }
 
-        public RddJsonResult(T value, IExpressionTree fields)
+        public RddJsonResult(T value, IExpressionTree<T> fields)
             : base(value)
         {
             Fields = fields;
         }
 
-        public RddJsonResult(ISelection<T> value, IExpressionTree fields)
+        public RddJsonResult(IEnumerable<T> value, IExpressionTree<T> fields)
+            : base(value)
+        {
+            Fields = fields;
+        }
+
+        public RddJsonResult(ISelection<T> value, IExpressionTree<T> fields)
             : base(value)
         {
             Fields = fields;

--- a/test/Rdd.Web.Tests/Serialization/FieldsTests.cs
+++ b/test/Rdd.Web.Tests/Serialization/FieldsTests.cs
@@ -26,13 +26,18 @@ namespace Rdd.Web.Tests.Serialization
     {
         protected static readonly DateTime GeneratedAt = new DateTime(2000, 01, 01, 0, 0, 0, DateTimeKind.Utc);
 
-        protected Task<string> SerializeAsync<T>(ISelection<T> selection, IExpressionTree fields)
+        protected Task<string> SerializeAsync<T>(ISelection<T> selection, IExpressionTree<T> fields)
+           where T : class
+        {
+            return SerializeCorrectedFieldsAsync(new RddJsonResult<T>(selection, fields));
+        }
+        protected Task<string> SerializeAsync<T>(IEnumerable<T> selection, IExpressionTree<T> fields)
            where T : class
         {
             return SerializeCorrectedFieldsAsync(new RddJsonResult<T>(selection, fields));
         }
 
-        protected Task<string> SerializeAsync<T>(T data, IExpressionTree fields)
+        protected Task<string> SerializeAsync<T>(T data, IExpressionTree<T> fields)
             where T : class
         {
             return SerializeCorrectedFieldsAsync(new RddJsonResult<T>(data, fields));
@@ -136,7 +141,7 @@ namespace Rdd.Web.Tests.Serialization
         public async Task DicoScenario1()
         {
             var obj1 = new Dictionary<string, int> { { "lol", 1 } };
-            var fields = new ExpressionTree();
+            var fields = new ExpressionTree<Dictionary<string, int>>();
 
             var json = await SerializeAsync(obj1, fields);
             Assert.Equal(ExpectedInput(@"{""lol"":1}"), json);

--- a/test/Rdd.Web.Tests/Serialization/PropertySerializerTests.cs
+++ b/test/Rdd.Web.Tests/Serialization/PropertySerializerTests.cs
@@ -26,7 +26,7 @@ namespace Rdd.Web.Tests.Serialization
         {
             var entity = new Domain.Tests.Models.Super();
             var entity2 = new Domain.Tests.Models.SuperSuper();
-            var fields = new ExpressionParser().ParseTree<Domain.Tests.Models.Super>("");
+            var fields = new ExpressionParser().ParseTree<Domain.Tests.Models.Hierarchy>("");
 
             var json = await SerializeAsync(entity, fields);
             Assert.Contains("superProperty", json);
@@ -177,7 +177,7 @@ namespace Rdd.Web.Tests.Serialization
                 new KeyValuePair<int, string>(3, "trois"),
             };
 
-            var json = await SerializeAsync(values, new ExpressionTree());
+            var json = await SerializeAsync(values, new ExpressionTree<List<KeyValuePair<int, string>>>());
 
             Assert.Equal(ExpectedInput(@"[{""key"":2,""value"":""deux""},{""key"":3,""value"":""trois""}]"), json);
         }


### PR DESCRIPTION
RddJsonResult accepted in its constructor a `IExpressionTree`, when what it expected really was a `IExpressionTree<T>`. This could lead to obscure error pretty hard to catch.

@GuillaumeNury will test that this pr does not break apis with hierarchy