### PR TITLE
FIX : synchronous writes

### DIFF
--- a/src/Rdd.Web/Serialization/Providers/ISerializerProvider.cs
+++ b/src/Rdd.Web/Serialization/Providers/ISerializerProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Rdd.Domain.Helpers.Expressions;
 using Rdd.Web.Serialization.Serializers;
+using System.Threading.Tasks;
 
 namespace Rdd.Web.Serialization.Providers
 {
@@ -11,8 +12,8 @@ namespace Rdd.Web.Serialization.Providers
 
     public static class ISerializerProviderExtensions
     {
-        public static void WriteJson(this ISerializerProvider serializerProvider, JsonTextWriter writer, object entity, IExpressionTree fields)
-            => serializerProvider.ResolveSerializer(entity).WriteJson(writer, entity, fields);
+        public static Task WriteJsonAsync(this ISerializerProvider serializerProvider, JsonTextWriter writer, object entity, IExpressionTree fields)
+            => serializerProvider.ResolveSerializer(entity).WriteJsonAsync(writer, entity, fields);
     }
 
 }

--- a/src/Rdd.Web/Serialization/RddJsonResult.cs
+++ b/src/Rdd.Web/Serialization/RddJsonResult.cs
@@ -100,7 +100,7 @@ namespace Rdd.Web.Serialization
                 jsonWriter.CloseOutput = false;
                 jsonWriter.AutoCompleteOnClose = false;
 
-                services.GetRequiredService<ISerializerProvider>().WriteJson(jsonWriter, Value, Fields);
+                await services.GetRequiredService<ISerializerProvider>().WriteJsonAsync(jsonWriter, Value, Fields);
             }
 
             // Perf: call FlushAsync to call WriteAsync on the stream with any content left in the TextWriter's

--- a/src/Rdd.Web/Serialization/Serializers/ArraySerializer.cs
+++ b/src/Rdd.Web/Serialization/Serializers/ArraySerializer.cs
@@ -2,6 +2,7 @@
 using Rdd.Domain.Helpers.Expressions;
 using Rdd.Web.Serialization.Providers;
 using System.Collections;
+using System.Threading.Tasks;
 
 namespace Rdd.Web.Serialization.Serializers
 {
@@ -14,21 +15,21 @@ namespace Rdd.Web.Serialization.Serializers
             SerializerProvider = serializerProvider;
         }
 
-        public virtual void WriteJson(JsonTextWriter writer, object entity, IExpressionTree fields)
+        public virtual Task WriteJsonAsync(JsonTextWriter writer, object entity, IExpressionTree fields)
         {
-            WriteJson(writer, (IEnumerable)entity, fields);
+            return WriteJsonAsync(writer, (IEnumerable)entity, fields);
         }
 
-        protected virtual void WriteJson(JsonTextWriter writer, IEnumerable entities, IExpressionTree fields)
+        protected async virtual Task WriteJsonAsync(JsonTextWriter writer, IEnumerable entities, IExpressionTree fields)
         {
-            writer.WriteStartArray();
+            await writer.WriteStartArrayAsync();
 
             foreach (object entity in entities)
             {
-                SerializerProvider.ResolveSerializer(entity).WriteJson(writer, entity, fields);
+                await SerializerProvider.ResolveSerializer(entity).WriteJsonAsync(writer, entity, fields);
             }
 
-            writer.WriteEndArray();
+            await writer.WriteEndArrayAsync();
         }
     }
 }

--- a/src/Rdd.Web/Serialization/Serializers/CultureInfoSerializer.cs
+++ b/src/Rdd.Web/Serialization/Serializers/CultureInfoSerializer.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Serialization;
 using Rdd.Domain.Helpers.Expressions;
 using Rdd.Web.Serialization.Providers;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Rdd.Web.Serialization.Serializers
 {
@@ -14,12 +15,13 @@ namespace Rdd.Web.Serialization.Serializers
         public CultureInfoSerializer(ISerializerProvider serializerProvider, NamingStrategy namingStrategy)
             : base(serializerProvider, namingStrategy) { }
 
-        protected override void SerializeProperty(JsonTextWriter writer, object entity, IExpressionTree fields, PropertyExpression property)
+        protected override Task SerializePropertyAsync(JsonTextWriter writer, object entity, IExpressionTree fields, PropertyExpression property)
         {
             if (_allowedProperties.Contains(property.Name))
             {
-                base.SerializeProperty(writer, entity, fields, property);
+                return base.SerializePropertyAsync(writer, entity, fields, property);
             }
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Rdd.Web/Serialization/Serializers/DictionarySerializer.cs
+++ b/src/Rdd.Web/Serialization/Serializers/DictionarySerializer.cs
@@ -4,6 +4,7 @@ using Rdd.Domain.Helpers.Expressions;
 using Rdd.Web.Serialization.Providers;
 using System;
 using System.Collections;
+using System.Threading.Tasks;
 
 namespace Rdd.Web.Serialization.Serializers
 {
@@ -18,19 +19,19 @@ namespace Rdd.Web.Serialization.Serializers
             NamingStrategy = namingStrategy ?? throw new ArgumentNullException(nameof(namingStrategy));
         }
 
-        public void WriteJson(JsonTextWriter writer, object entity, IExpressionTree fields)
-            => WriteJson(writer, entity as IDictionary, fields);
+        public Task WriteJsonAsync(JsonTextWriter writer, object entity, IExpressionTree fields)
+            => WriteJsonAsync(writer, entity as IDictionary, fields);
 
-        protected void WriteJson(JsonTextWriter writer, IDictionary dico, IExpressionTree fields)
+        protected async Task WriteJsonAsync(JsonTextWriter writer, IDictionary dico, IExpressionTree fields)
         {
-            writer.WriteStartObject();
+            await writer.WriteStartObjectAsync();
 
             if (fields.Children.Count != 0)
             {
                 foreach (var child in fields.Children)
                 {
                     var concreteChild = child.Node as ItemExpression;
-                    WriteKvp(writer, NamingStrategy.GetDictionaryKey(concreteChild.Name), dico[concreteChild.Name], child);
+                    await WriteKvpAsync(writer, NamingStrategy.GetDictionaryKey(concreteChild.Name), dico[concreteChild.Name], child);
                 }
             }
             else
@@ -40,17 +41,17 @@ namespace Rdd.Web.Serialization.Serializers
                 while (enumerator.MoveNext())
                 {
                     var entry = enumerator.Entry;
-                    WriteKvp(writer, NamingStrategy.GetDictionaryKey(entry.Key.ToString()), entry.Value, fields);
+                    await WriteKvpAsync(writer, NamingStrategy.GetDictionaryKey(entry.Key.ToString()), entry.Value, fields);
                 }
             }
 
-            writer.WriteEndObject();
+            await writer.WriteEndObjectAsync();
         }
 
-        protected virtual void WriteKvp(JsonTextWriter writer, string key, object value, IExpressionTree fields)
+        protected virtual async Task WriteKvpAsync(JsonTextWriter writer, string key, object value, IExpressionTree fields)
         {
-            writer.WritePropertyName(key, true);
-            SerializerProvider.ResolveSerializer(value).WriteJson(writer, value, fields);
+            await writer.WritePropertyNameAsync(key, true);
+            await SerializerProvider.ResolveSerializer(value).WriteJsonAsync(writer, value, fields);
         }
     }
 }

--- a/src/Rdd.Web/Serialization/Serializers/ISerializer.cs
+++ b/src/Rdd.Web/Serialization/Serializers/ISerializer.cs
@@ -1,10 +1,11 @@
 ﻿using Newtonsoft.Json;
 using Rdd.Domain.Helpers.Expressions;
+using System.Threading.Tasks;
 
 namespace Rdd.Web.Serialization.Serializers
 {
     public interface ISerializer
     {
-        void WriteJson(JsonTextWriter writer, object entity, IExpressionTree fields);
+        Task WriteJsonAsync(JsonTextWriter writer, object entity, IExpressionTree fields);
     }
 }

--- a/src/Rdd.Web/Serialization/Serializers/MetadataSerializer.cs
+++ b/src/Rdd.Web/Serialization/Serializers/MetadataSerializer.cs
@@ -4,6 +4,7 @@ using Rdd.Domain.Helpers.Expressions;
 using Rdd.Web.Models;
 using Rdd.Web.Serialization.Providers;
 using System;
+using System.Threading.Tasks;
 
 namespace Rdd.Web.Serialization.Serializers
 {
@@ -18,27 +19,27 @@ namespace Rdd.Web.Serialization.Serializers
             NamingStrategy = namingStrategy ?? throw new ArgumentNullException(nameof(namingStrategy));
         }
 
-        public void WriteJson(JsonTextWriter writer, object entity, IExpressionTree fields)
+        public async Task WriteJsonAsync(JsonTextWriter writer, object entity, IExpressionTree fields)
         {
             var content = entity as Metadata;
 
-            writer.WriteStartObject();
+            await writer.WriteStartObjectAsync();
             {
-                writer.WritePropertyName(GetKey(nameof(Metadata.Header)), true);
-                writer.WriteStartObject();
+                await writer.WritePropertyNameAsync(GetKey(nameof(Metadata.Header)), true);
+                await writer.WriteStartObjectAsync();
                 {
-                    writer.WritePropertyName(GetKey(nameof(MetadataHeader.Generated)), true);
-                    writer.WriteValue(DateTime.SpecifyKind(content.Header.Generated, DateTimeKind.Unspecified));
+                    await writer.WritePropertyNameAsync(GetKey(nameof(MetadataHeader.Generated)), true);
+                    await writer.WriteValueAsync(DateTime.SpecifyKind(content.Header.Generated, DateTimeKind.Unspecified));
 
-                    writer.WritePropertyName(GetKey(nameof(MetadataHeader.Principal)), true);
-                    writer.WriteValue(content.Header.Principal);
+                    await writer.WritePropertyNameAsync(GetKey(nameof(MetadataHeader.Principal)), true);
+                    await writer.WriteValueAsync(content.Header.Principal);
                 }
-                writer.WriteEndObject();
+                await writer.WriteEndObjectAsync();
 
-                writer.WritePropertyName(GetKey(nameof(Metadata.Data)), true);
-                SerializerProvider.ResolveSerializer(content.Data).WriteJson(writer, content.Data, fields);
+                await writer.WritePropertyNameAsync(GetKey(nameof(Metadata.Data)), true);
+                await SerializerProvider.ResolveSerializer(content.Data).WriteJsonAsync(writer, content.Data, fields);
             }
-            writer.WriteEndObject();
+            await writer.WriteEndObjectAsync();
         }
 
         protected string GetKey(string key) => NamingStrategy.GetPropertyName(key, false);

--- a/src/Rdd.Web/Serialization/Serializers/ObjectSerializer.cs
+++ b/src/Rdd.Web/Serialization/Serializers/ObjectSerializer.cs
@@ -5,6 +5,7 @@ using Rdd.Web.Serialization.Providers;
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Rdd.Web.Serialization.Serializers
 {
@@ -21,16 +22,16 @@ namespace Rdd.Web.Serialization.Serializers
             DefaultFields = new ConcurrentDictionary<Type, IExpressionTree>();
         }
 
-        public virtual void WriteJson(JsonTextWriter writer, object entity, IExpressionTree fields)
+        public virtual async Task WriteJsonAsync(JsonTextWriter writer, object entity, IExpressionTree fields)
         {
-            writer.WriteStartObject();
+            await writer.WriteStartObjectAsync();
 
             foreach (var subSelector in CorrectFields(entity, fields).Children)
             {
-                SerializeProperty(writer, entity, subSelector);
+                await SerializePropertyAsync(writer, entity, subSelector);
             }
 
-            writer.WriteEndObject();
+            await writer.WriteEndObjectAsync();
         }
 
         protected virtual IExpressionTree CorrectFields(object entity, IExpressionTree fields)
@@ -43,20 +44,20 @@ namespace Rdd.Web.Serialization.Serializers
             return fields;
         }
 
-        protected virtual void SerializeProperty(JsonTextWriter writer, object entity, IExpressionTree fields)
+        protected virtual Task SerializePropertyAsync(JsonTextWriter writer, object entity, IExpressionTree fields)
         {
-            SerializeProperty(writer, entity, fields, fields.Node as PropertyExpression);
+            return SerializePropertyAsync(writer, entity, fields, fields.Node as PropertyExpression);
         }
 
-        protected virtual void SerializeProperty(JsonTextWriter writer, object entity, IExpressionTree fields, PropertyExpression property)
+        protected virtual Task SerializePropertyAsync(JsonTextWriter writer, object entity, IExpressionTree fields, PropertyExpression property)
         {
-            WriteKvp(writer, GetKey(entity, fields, property), GetRawValue(entity, fields, property), fields, property);
+            return WriteKvpAsync(writer, GetKey(entity, fields, property), GetRawValue(entity, fields, property), fields, property);
         }
 
-        protected virtual void WriteKvp(JsonTextWriter writer, string key, object value, IExpressionTree fields, PropertyExpression property)
+        protected virtual async Task WriteKvpAsync(JsonTextWriter writer, string key, object value, IExpressionTree fields, PropertyExpression property)
         {
-            writer.WritePropertyName(key, true);
-            SerializerProvider.ResolveSerializer(value).WriteJson(writer, value, fields);
+            await writer.WritePropertyNameAsync(key, true);
+            await SerializerProvider.ResolveSerializer(value).WriteJsonAsync(writer, value, fields);
         }
 
         protected virtual string GetKey(object entity, IExpressionTree fields, PropertyExpression property)

--- a/src/Rdd.Web/Serialization/Serializers/SelectionSerializer.cs
+++ b/src/Rdd.Web/Serialization/Serializers/SelectionSerializer.cs
@@ -4,6 +4,7 @@ using Rdd.Domain;
 using Rdd.Domain.Helpers.Expressions;
 using Rdd.Web.Serialization.Providers;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Rdd.Web.Serialization.Serializers
 {
@@ -12,10 +13,10 @@ namespace Rdd.Web.Serialization.Serializers
         public SelectionSerializer(ISerializerProvider serializerProvider, NamingStrategy namingStrategy)
             : base(serializerProvider, namingStrategy) { }
 
-        public override void WriteJson(JsonTextWriter writer, object entity, IExpressionTree fields)
-            => WriteJson(writer, entity as ISelection, fields);
+        public override Task WriteJsonAsync(JsonTextWriter writer, object entity, IExpressionTree fields)
+            => WriteJsonAsync(writer, entity as ISelection, fields);
 
-        protected void WriteJson(JsonTextWriter writer, ISelection selection, IExpressionTree fields)
+        protected async Task WriteJsonAsync(JsonTextWriter writer, ISelection selection, IExpressionTree fields)
         {
             var countField = fields.Children.FirstOrDefault(c => c.Node.Name == nameof(ISelection.Count) && typeof(ISelection).IsAssignableFrom(c.Node.ToLambdaExpression().Parameters[0].Type));
 
@@ -25,20 +26,20 @@ namespace Rdd.Web.Serialization.Serializers
                 Children = fields.Children.Where(c => c != countField).ToList()
             };
 
-            writer.WriteStartObject();
+            await writer.WriteStartObjectAsync();
 
             if (countField == null || normalFields.Children.Count != 0)
             {
                 var items = selection.GetItems();
-                WriteKvp(writer, NamingStrategy.GetPropertyName("items", false), items, normalFields, null);
+                await WriteKvpAsync(writer, NamingStrategy.GetPropertyName("items", false), items, normalFields, null);
             }
 
             if (countField != null)
             {
-                SerializeProperty(writer, selection, countField);
+                await SerializePropertyAsync(writer, selection, countField);
             }
 
-            writer.WriteEndObject();
+            await writer.WriteEndObjectAsync();
         }
     }
 }

--- a/src/Rdd.Web/Serialization/Serializers/ToStringSerializer.cs
+++ b/src/Rdd.Web/Serialization/Serializers/ToStringSerializer.cs
@@ -1,11 +1,12 @@
 ﻿using Newtonsoft.Json;
 using Rdd.Domain.Helpers.Expressions;
+using System.Threading.Tasks;
 
 namespace Rdd.Web.Serialization.Serializers
 {
     public class ToStringSerializer : ISerializer
     {
-        public void WriteJson(JsonTextWriter writer, object entity, IExpressionTree fields)
-            => writer.WriteValue(entity.ToString());
+        public Task WriteJsonAsync(JsonTextWriter writer, object entity, IExpressionTree fields)
+            => writer.WriteValueAsync(entity.ToString());
     }
 }

--- a/src/Rdd.Web/Serialization/Serializers/ValueSerializer.cs
+++ b/src/Rdd.Web/Serialization/Serializers/ValueSerializer.cs
@@ -1,11 +1,12 @@
 ﻿using Newtonsoft.Json;
 using Rdd.Domain.Helpers.Expressions;
+using System.Threading.Tasks;
 
 namespace Rdd.Web.Serialization.Serializers
 {
     public class ValueSerializer : ISerializer
     {
-        public void WriteJson(JsonTextWriter writer, object entity, IExpressionTree fields)
-            => writer.WriteValue(entity);
+        public Task WriteJsonAsync(JsonTextWriter writer, object entity, IExpressionTree fields)
+            => writer.WriteValueAsync(entity);
     }
 }


### PR DESCRIPTION
when the json payload gets too big => syncronous I.O because of rdd serialization

That PRs fixes it, but comes with breaking changes on some public apis. hould not be a too big issue i suppose, but still annoying