### PR TITLE
FIX : .contains on expresion on hierarchy

### DIFF
--- a/src/Rdd.Domain/Helpers/Expressions/ExpressionParser.cs
+++ b/src/Rdd.Domain/Helpers/Expressions/ExpressionParser.cs
@@ -100,7 +100,8 @@ namespace Rdd.Domain.Helpers.Expressions
             if (typeof(IDictionary).IsAssignableFrom(classType))
             {
                 var dictionaryKey = Expression.Constant(member);
-                var itemsExpression = Expression.Property(parameter, "Item", dictionaryKey);
+                var itemProperty = GetPropertyInfo(classType, "Item");
+                var itemsExpression = Expression.Property(parameter, itemProperty, dictionaryKey);
 
                 return new ItemExpression { LambdaExpression = Expression.Lambda(itemsExpression, parameter) };
             }

--- a/src/Rdd.Domain/Helpers/Expressions/Utils/ExpressionChainExtractor.cs
+++ b/src/Rdd.Domain/Helpers/Expressions/Utils/ExpressionChainExtractor.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace Rdd.Domain.Helpers.Expressions.Utils
 {
@@ -70,6 +71,12 @@ namespace Rdd.Domain.Helpers.Expressions.Utils
         {
             var parameter = Expression.Parameter(node.Expression.Type);
             var propertyExpression = Expression.PropertyOrField(parameter, node.Member.Name);
+            //Ef needs the property coming from the declaring type
+            if (propertyExpression.Member.ReflectedType != propertyExpression.Member.DeclaringType)
+            {
+                var property = propertyExpression.Member.DeclaringType.GetProperty(node.Member.Name, BindingFlags.FlattenHierarchy | BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                propertyExpression = Expression.Property(parameter, property);
+            }
             var lambda = Expression.Lambda(propertyExpression, parameter);
 
             if (typeof(IEnumerable).IsAssignableFrom(node.Expression.Type) && node.Expression.Type != typeof(string))

--- a/test/Rdd.Web.Tests/Serialization/FieldsTests.cs
+++ b/test/Rdd.Web.Tests/Serialization/FieldsTests.cs
@@ -223,6 +223,17 @@ namespace Rdd.Web.Tests.Serialization
 
             Assert.Equal(ExpectedInput(@"{""items"":[{""obj2s"":[{""id"":1,""name"":""1""},{""id"":2,""name"":""2""}]}]}"), json);
         }
+
+        [Fact]
+        public void FieldsContainsOnHierarchy()
+        {
+            var tree = new ExpressionParser().ParseTree<Super>("value,value2,baseproperty,superproperty");
+
+            Assert.True(tree.Contains(s => s.SuperProperty));
+            Assert.True(tree.Contains(s => s.Value2));
+            Assert.True(tree.Contains(s => s.Value));
+            Assert.True(tree.Contains(s => s.BaseProperty));
+        }
     }
 
     public class Obj1 : IEntityBase<int>


### PR DESCRIPTION
the contains method failed on property of base classes since patch 4.0.1