### PR TITLE
adds Z.EntityFramework IncludeOptimize feature

### DIFF
--- a/src/Rdd.Domain/Models/Querying/Options.cs
+++ b/src/Rdd.Domain/Models/Querying/Options.cs
@@ -10,6 +10,13 @@
 
         public bool NeedsDataTracking { get; set; }
 
+        /// <summary>
+        /// Warning : use only in case of multiple includes, and by testing the behavior before and after enabling this.
+        /// This property can lead to under-perform in some cases, so use it with caution
+        /// https://entityframework-plus.net/query-include-optimized
+        /// </summary>
+        public bool OptimizeIncludes { get; set; }
+
         public Options()
         {
             NeedsEnumeration = true;

--- a/src/Rdd.Domain/Models/Querying/Query.cs
+++ b/src/Rdd.Domain/Models/Querying/Query.cs
@@ -15,14 +15,7 @@ namespace Rdd.Domain.Models.Querying
         public List<OrderBy<TEntity>> OrderBys { get; set; }
         public Page Page { get; set; }
         public Options Options { get; set; }
-        
-        /// <summary>
-        /// Warning : use only in case of multiple includes, and by testing the behavior before and after enabling this.
-        /// This property can lead to under-perform in some cases, so use it with caution
-        /// https://entityframework-plus.net/query-include-optimized
-        /// </summary>
-        public bool OptimizeIncludes { get; set; }
-
+       
         public Query()
         {
             Verb = HttpVerbs.Get;

--- a/src/Rdd.Domain/Models/Querying/Query.cs
+++ b/src/Rdd.Domain/Models/Querying/Query.cs
@@ -15,6 +15,13 @@ namespace Rdd.Domain.Models.Querying
         public List<OrderBy<TEntity>> OrderBys { get; set; }
         public Page Page { get; set; }
         public Options Options { get; set; }
+        
+        /// <summary>
+        /// Warning : use only in case of multiple includes, and by testing the behavior before and after enabling this.
+        /// This property can lead to under-perform in some cases, so use it with caution
+        /// https://entityframework-plus.net/query-include-optimized
+        /// </summary>
+        public bool OptimizeIncludes { get; set; }
 
         public Query()
         {

--- a/src/Rdd.Infra/Rdd.Infra.csproj
+++ b/src/Rdd.Infra/Rdd.Infra.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
+    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="3.0.48" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
+++ b/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
@@ -123,7 +123,7 @@ namespace Rdd.Infra.Storage
                 return entities;
             }
 
-            if (query.OptimizeIncludes)
+            if (query.Options.OptimizeIncludes)
             {
                 QueryIncludeOptimizedManager.AllowIncludeSubPath = true;
                 foreach (var prop in query.Fields.Intersection(IncludeWhiteList))

--- a/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
+++ b/src/Rdd.Infra/Storage/ReadOnlyRepository.cs
@@ -6,6 +6,7 @@ using Rdd.Domain.Rights;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Z.EntityFramework.Plus;
 
 namespace Rdd.Infra.Storage
 {
@@ -122,9 +123,20 @@ namespace Rdd.Infra.Storage
                 return entities;
             }
 
-            foreach (var prop in query.Fields.Intersection(IncludeWhiteList))
+            if (query.OptimizeIncludes)
             {
-                entities = entities.Include(prop.Name);
+                QueryIncludeOptimizedManager.AllowIncludeSubPath = true;
+                foreach (var prop in query.Fields.Intersection(IncludeWhiteList))
+                {
+                    entities = entities.IncludeOptimizedByPath(prop.Name);
+                }
+            }
+            else
+            {
+                foreach (var prop in query.Fields.Intersection(IncludeWhiteList))
+                {
+                    entities = entities.Include(prop.Name);
+                }
             }
 
             return entities;


### PR DESCRIPTION
Adds support of Z.EntityFramework IncludeOptimize feature.

- this feature is OPT-IN 
- use https://entityframework-plus.net/query-include-optimized
- there's no breaking change in default behavior
- this optimization should be used in a case per case basis

Warnings : 

- DO NOT work with AsNoTracking
- Cannot be mixed with projection
- Cannot be mixed with Include (Include doesn't support projection)
- Cannot be mixed with IncludeFilter
- Many to Many relation: Not supported yet
- Relationship: Entities will contain all previously loaded related entities even if the Query does not return them. It's a limitation due to how Entity Framework relation work.