### PR TITLE
decoupling Z.EntityFramework assembly

### DIFF
--- a/Rdd.sln
+++ b/Rdd.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2005
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rdd.Domain", "src\Rdd.Domain\Rdd.Domain.csproj", "{64D838DB-55D3-4F2E-8EDB-CF1866B3939B}"
 EndProject
@@ -25,6 +25,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rdd.Web.Tests", "test\Rdd.Web.Tests\Rdd.Web.Tests.csproj", "{D4493283-1C57-48C9-BA9D-4C7862A40424}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RDD.Web.AutoMapper", "src\RDD.Web.AutoMapper\RDD.Web.AutoMapper.csproj", "{D3FD8EE1-EDF0-48D9-86E8-FC2BE1D6CB6C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rdd.Z.EntityFramework", "src\Rdd.Z.EntityFramework\Rdd.Z.EntityFramework.csproj", "{0269E680-7BB8-4441-AF99-943F3DB8CCF6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -64,6 +66,10 @@ Global
 		{D3FD8EE1-EDF0-48D9-86E8-FC2BE1D6CB6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3FD8EE1-EDF0-48D9-86E8-FC2BE1D6CB6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3FD8EE1-EDF0-48D9-86E8-FC2BE1D6CB6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0269E680-7BB8-4441-AF99-943F3DB8CCF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0269E680-7BB8-4441-AF99-943F3DB8CCF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0269E680-7BB8-4441-AF99-943F3DB8CCF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0269E680-7BB8-4441-AF99-943F3DB8CCF6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,6 +68,7 @@ after_test:
 - ps: dotnet pack src\Rdd.Application\Rdd.Application.csproj --include-symbols -p:SymbolPackageFormat=snupkg /p:$("VersionPrefix="+$version.Prefix+";VersionSuffix="+$version.Suffix) /p:Configuration=Release /p:PackageVersion=$env:APPVEYOR_BUILD_VERSION -o artifacts
 - ps: dotnet pack src\Rdd.Web\Rdd.Web.csproj --include-symbols -p:SymbolPackageFormat=snupkg /p:$("VersionPrefix="+$version.Prefix+";VersionSuffix="+$version.Suffix) /p:Configuration=Release /p:PackageVersion=$env:APPVEYOR_BUILD_VERSION -o artifacts
 - ps: dotnet pack src\RDD.Web.AutoMapper\RDD.Web.AutoMapper.csproj --include-symbols -p:SymbolPackageFormat=snupkg /p:$("VersionPrefix="+$version.Prefix+";VersionSuffix="+$version.Suffix) /p:Configuration=Release /p:PackageVersion=$env:APPVEYOR_BUILD_VERSION -o artifacts
+- ps: dotnet pack src\Rdd.Z.EntityFramework\Rdd.Z.EntityFramework.csproj --include-symbols -p:SymbolPackageFormat=snupkg /p:$("VersionPrefix="+$version.Prefix+";VersionSuffix="+$version.Suffix) /p:Configuration=Release /p:PackageVersion=$env:APPVEYOR_BUILD_VERSION -o artifacts
 - echo Starting Myget publish
 - ps: if($env:deploy_unstable -eq "true") { foreach ($nuget in Get-ChildItem -Path .\artifacts\* -Include *.nupkg) { nuget push $nuget $env:MYGET_TOKEN -Source https://www.myget.org/F/lucca/api/v2/package -SymbolSource https://www.myget.org/F/lucca/symbols/api/v2/package -SymbolApiKey $env:MYGET_TOKEN } }
 

--- a/src/Rdd.Domain/IIncludeApplicator.cs
+++ b/src/Rdd.Domain/IIncludeApplicator.cs
@@ -1,0 +1,12 @@
+﻿using System.Linq;
+using Rdd.Domain.Helpers.Expressions;
+using Rdd.Domain.Models.Querying;
+
+namespace Rdd.Domain
+{
+    public interface IIncludeApplicator
+    {
+        IQueryable<TEntity> ApplyIncludes<TEntity>(IQueryable<TEntity> entities, Query<TEntity> query, IExpressionTree includeWhiteList)
+            where TEntity : class;
+    }
+}

--- a/src/Rdd.Domain/Models/Querying/Options.cs
+++ b/src/Rdd.Domain/Models/Querying/Options.cs
@@ -1,4 +1,6 @@
-﻿namespace Rdd.Domain.Models.Querying
+﻿using System.Collections.Generic;
+
+namespace Rdd.Domain.Models.Querying
 {
     public class Options
     {
@@ -10,12 +12,7 @@
 
         public bool NeedsDataTracking { get; set; }
 
-        /// <summary>
-        /// Warning : use only in case of multiple includes, and by testing the behavior before and after enabling this.
-        /// This property can lead to under-perform in some cases, so use it with caution
-        /// https://entityframework-plus.net/query-include-optimized
-        /// </summary>
-        public bool OptimizeIncludes { get; set; }
+        public Dictionary<string,object> CustomOptions { get; set; }
 
         public Options()
         {

--- a/src/Rdd.Infra/Rdd.Infra.csproj
+++ b/src/Rdd.Infra/Rdd.Infra.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.0" />
-    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="3.0.48" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rdd.Infra/Storage/IncludeApplicator.cs
+++ b/src/Rdd.Infra/Storage/IncludeApplicator.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Rdd.Domain;
+using Rdd.Domain.Helpers.Expressions;
+using Rdd.Domain.Models.Querying;
+
+namespace Rdd.Infra.Storage
+{
+    public sealed class IncludeApplicator : IIncludeApplicator
+    {
+        public IQueryable<TEntity> ApplyIncludes<TEntity>(IQueryable<TEntity> entities, Query<TEntity> query, IExpressionTree includeWhiteList)
+            where TEntity : class
+        {
+            if (includeWhiteList == null || query.Fields == null)
+            {
+                return entities;
+            }
+
+            foreach (var prop in query.Fields.Intersection(includeWhiteList))
+            {
+                entities = entities.Include(prop.Name);
+            }
+
+            return entities;
+        }
+    }
+}

--- a/src/Rdd.Infra/Storage/Repository.cs
+++ b/src/Rdd.Infra/Storage/Repository.cs
@@ -14,8 +14,8 @@ namespace Rdd.Infra.Storage
     public class Repository<TEntity> : ReadOnlyRepository<TEntity>, IRepository<TEntity>
         where TEntity : class
     {
-        public Repository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightExpressionsHelper)
-            : base(storageService, rightExpressionsHelper) { }
+        public Repository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightExpressionsHelper, IIncludeApplicator includeApplicator)
+            : base(storageService, rightExpressionsHelper, includeApplicator) { }
 
         public virtual async Task AddAsync(TEntity entity, Query<TEntity> query)
         {

--- a/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
+++ b/src/Rdd.Web/Helpers/RddServiceCollectionExtensions.cs
@@ -70,7 +70,7 @@ namespace Rdd.Web.Helpers
             services.TryAddSingleton<IFieldsParser, FieldsParser>();
             services.TryAddSingleton<IOrderByParser, OrderByParser>();
             services.TryAddSingleton(typeof(IQueryParser<>), typeof(QueryParser<>));
-
+            services.TryAddSingleton<IIncludeApplicator, IncludeApplicator>();
             //scoped services
             services.TryAddScoped<DbContext>(p => p.GetRequiredService<TDbContext>());
             services.TryAddScoped<IStorageService, EFStorageService>();

--- a/src/Rdd.Z.EntityFramework/Rdd.Z.EntityFramework.csproj
+++ b/src/Rdd.Z.EntityFramework/Rdd.Z.EntityFramework.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="3.0.48" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Rdd.Domain\Rdd.Domain.csproj" />
+    <ProjectReference Include="..\Rdd.Web\Rdd.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Rdd.Z.EntityFramework/ZEntityExtensions.cs
+++ b/src/Rdd.Z.EntityFramework/ZEntityExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Rdd.Domain;
+using Rdd.Domain.Models.Querying;
+using Rdd.Web.Helpers;
+
+namespace Rdd.Z.EntityFramework
+{
+    public static class ZEntityExtensions
+    {
+        private const string OptimizeIncludes = "OptimizeIncludes";
+
+        public static RddBuilder AddZEntityOptimizeInclude(this RddBuilder rddBuilder)
+        {
+            rddBuilder.Services.AddSingleton<IIncludeApplicator, ZEntityIncludeApplicator>();
+            return rddBuilder;
+        }
+
+        /// <summary>
+        /// Warning : use only in case of multiple includes, and by testing the behavior before and after enabling this.
+        /// This property can lead to under-perform in some cases, so use it with caution
+        /// https://entityframework-plus.net/query-include-optimized
+        /// </summary>
+        public static void ForceOptimizeIncludes<TEntity>(this Query<TEntity> query, bool optimize)
+            where TEntity : class
+        {
+            if (query.Options.CustomOptions == null)
+            {
+                query.Options.CustomOptions = new Dictionary<string, object> {{OptimizeIncludes, true}};
+            }
+            else
+            {
+                query.Options.CustomOptions.Add(OptimizeIncludes, true);
+            }
+        }
+
+        internal static bool GetOptimizeIncludes<TEntity>(this Query<TEntity> query)
+            where TEntity : class
+        {
+            if (query.Options.CustomOptions != null
+                && query.Options.CustomOptions.TryGetValue(OptimizeIncludes, out object found)
+                && found is bool val)
+            {
+                return val;
+            }
+            return false;
+        }
+    }
+}

--- a/src/Rdd.Z.EntityFramework/ZEntityIncludeApplicator.cs
+++ b/src/Rdd.Z.EntityFramework/ZEntityIncludeApplicator.cs
@@ -1,0 +1,42 @@
+﻿using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Rdd.Domain;
+using Rdd.Domain.Helpers.Expressions;
+using Rdd.Domain.Models.Querying;
+using Z.EntityFramework.Plus;
+
+namespace Rdd.Z.EntityFramework
+{
+    public class ZEntityIncludeApplicator : IIncludeApplicator
+    {
+        static ZEntityIncludeApplicator()
+        {
+            QueryIncludeOptimizedManager.AllowIncludeSubPath = true;
+        }
+
+        public IQueryable<TEntity> ApplyIncludes<TEntity>(IQueryable<TEntity> entities, Query<TEntity> query, IExpressionTree includeWhiteList) where TEntity : class
+        {
+            if (includeWhiteList == null || query.Fields == null)
+            {
+                return entities;
+            }
+
+            if (query.GetOptimizeIncludes())
+            {
+                foreach (var prop in query.Fields.Intersection(includeWhiteList))
+                {
+                    entities = entities.IncludeOptimizedByPath(prop.Name);
+                }
+            }
+            else
+            {
+                foreach (var prop in query.Fields.Intersection(includeWhiteList))
+                {
+                    entities = entities.Include(prop.Name);
+                }
+            }
+
+            return entities;
+        }
+    }
+}

--- a/test/Rdd.Domain.Tests/AppControllerTests.cs
+++ b/test/Rdd.Domain.Tests/AppControllerTests.cs
@@ -50,7 +50,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task PostShouldFailedIfForbidden()
         {
-            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>());
+            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>(), _fixture.IncludeApplicator);
             var users = new UsersCollectionWithHardcodedGetById(repo, _fixture.PatcherProvider, _fixture.Instanciator);
             var controller = new UsersAppController(_fixture.InMemoryStorage, users);
             var query = new Query<User> { Verb = Helpers.HttpVerbs.Post };
@@ -63,7 +63,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task PostShouldWorkIfForbiddenButExplicitelyAllowed()
         {
-            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>());
+            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>(), _fixture.IncludeApplicator);
             var users = new UsersCollectionWithHardcodedGetById(repo, _fixture.PatcherProvider, _fixture.Instanciator);
             var controller = new UsersAppController(_fixture.InMemoryStorage, users);
             var query = new Query<User> { Verb = Helpers.HttpVerbs.Post };
@@ -96,7 +96,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task PostOnCollectionShouldFailedIfForbidden()
         {
-            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>());
+            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>(), _fixture.IncludeApplicator);
             var users = new UsersCollectionWithHardcodedGetById(repo, _fixture.PatcherProvider, _fixture.Instanciator);
             var controller = new UsersAppController(_fixture.InMemoryStorage, users);
             var query = new Query<User> { Verb = Helpers.HttpVerbs.Post };
@@ -111,7 +111,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task PostOnCollectionShouldWorkIfForbiddenButExplicitelyAllowed()
         {
-            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>());
+            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>(), _fixture.IncludeApplicator);
             var users = new UsersCollectionWithHardcodedGetById(repo, _fixture.PatcherProvider, _fixture.Instanciator);
             var controller = new UsersAppController(_fixture.InMemoryStorage, users);
             var query = new Query<User>();
@@ -144,7 +144,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task CreateAsyncCollectionShouldFailedIfForbidden()
         {
-            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>());
+            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>(), _fixture.IncludeApplicator);
             var users = new UsersCollectionWithHardcodedGetById(repo, _fixture.PatcherProvider, _fixture.Instanciator);
             var controller = new UsersAppController(_fixture.InMemoryStorage, users);
 
@@ -154,7 +154,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task CreateAsyncCollectionShouldWorkIfForbiddenButExplicitelyAllowed()
         {
-            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>());
+            var repo = new Repository<User>(_fixture.InMemoryStorage, new ClosedRightExpressionsHelper<User>(), _fixture.IncludeApplicator);
             var users = new UsersCollectionWithHardcodedGetById(repo, _fixture.PatcherProvider, _fixture.Instanciator);
             var controller = new UsersAppController(_fixture.InMemoryStorage, users);
             var id1 = Guid.NewGuid();

--- a/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
+++ b/test/Rdd.Domain.Tests/CollectionMethodsTests.cs
@@ -62,7 +62,7 @@ namespace Rdd.Domain.Tests
             rightService.Setup(s => s.GetFilterAsync(It.IsAny<Query<User>>())).Returns(Task.FromResult(trueFilter));
 
             var id = Guid.NewGuid();
-            var repo = new Repository<User>(_fixture.InMemoryStorage, rightService.Object);
+            var repo = new Repository<User>(_fixture.InMemoryStorage, rightService.Object,_fixture.IncludeApplicator);
             var users = new UsersCollection(repo, _fixture.PatcherProvider, _fixture.Instanciator);
             var app = new UsersAppController(_fixture.InMemoryStorage, users);
             var candidate1 = _parser.Parse<User, Guid>($@"{{ ""id"": ""{id}"" }}");
@@ -97,7 +97,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task Post_SHOULD_work_WHEN_InstantiateEntityIsOverridenAndEntityHasParametersInConstructor()
         {
-            var repo = new Repository<UserWithParameters>(_fixture.InMemoryStorage, new OpenRightExpressionsHelper<UserWithParameters>());
+            var repo = new Repository<UserWithParameters>(_fixture.InMemoryStorage, new OpenRightExpressionsHelper<UserWithParameters>(), _fixture.IncludeApplicator);
             var users = new UsersCollectionWithParameters(repo, _fixture.PatcherProvider, new InstanciatorImplementation());
             var query = new Query<UserWithParameters>();
             query.Options.ChecksRights = false;
@@ -196,7 +196,7 @@ namespace Rdd.Domain.Tests
         {
             await Assert.ThrowsAsync<BadRequestException>(async () =>
             {
-                var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object);
+                var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new Mock<IRightExpressionsHelper<Hierarchy>>().Object, _fixture.IncludeApplicator);
                 var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
                 var collection = new RestCollection<Hierarchy, int>(repo, new ObjectPatcher<Hierarchy>(_fixture.PatcherProvider, _fixture.ReflectionHelper), instanciator);
 
@@ -208,7 +208,7 @@ namespace Rdd.Domain.Tests
         [Fact]
         public async Task BaseClass_Collection_on_hierarchy_works()
         {
-            var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new OpenRightExpressionsHelper<Hierarchy>());
+            var repo = new Repository<Hierarchy>(_fixture.InMemoryStorage, new OpenRightExpressionsHelper<Hierarchy>(), _fixture.IncludeApplicator);
             var instanciator = new BaseClassInstanciator<Hierarchy>(new InheritanceConfiguration());
             var collection = new RestCollection<Hierarchy, int>(repo, new BaseClassPatcher<Hierarchy>(_fixture.PatcherProvider, _fixture.ReflectionHelper, new InheritanceConfiguration()), instanciator);
 

--- a/test/Rdd.Domain.Tests/DefaultFixture.cs
+++ b/test/Rdd.Domain.Tests/DefaultFixture.cs
@@ -19,7 +19,7 @@ namespace Rdd.Domain.Tests
         public IInstanciator<User> Instanciator { get; private set; }
         public InMemoryStorageService InMemoryStorage { get; private set; }
         public IRepository<User> UsersRepo { get; private set; }
-
+        public IIncludeApplicator IncludeApplicator { get; }
         public DefaultFixture()
         {
             var services = new ServiceCollection();
@@ -31,13 +31,14 @@ namespace Rdd.Domain.Tests
             services.TryAddSingleton<ValuePatcher>();
             services.TryAddSingleton<DynamicPatcher>();
             services.TryAddSingleton<ObjectPatcher>();
-
+            services.TryAddSingleton<IIncludeApplicator, IncludeApplicator>();
             ServiceProvider = services.BuildServiceProvider();
 
             RightsService = new OpenRightExpressionsHelper<User>();
             Instanciator = new DefaultInstanciator<User>();
             InMemoryStorage = new InMemoryStorageService();
-            UsersRepo = new Repository<User>(InMemoryStorage, RightsService);
+            IncludeApplicator = ServiceProvider.GetRequiredService<IIncludeApplicator>();
+            UsersRepo = new Repository<User>(InMemoryStorage, RightsService, IncludeApplicator);
         }
 
         public void Dispose() { }

--- a/test/Rdd.Domain.Tests/Models/OpenRepository.cs
+++ b/test/Rdd.Domain.Tests/Models/OpenRepository.cs
@@ -10,7 +10,7 @@ namespace Rdd.Domain.Tests.Models
         where TEntity : class
     {
         public OpenRepository(IStorageService storageService, IRightExpressionsHelper<TEntity> rightsService)
-        : base(storageService, rightsService) { }
+        : base(storageService, rightsService, new IncludeApplicator()) { }
 
         protected override async Task<IQueryable<TEntity>> ApplyRightsAsync(IQueryable<TEntity> entities, Query<TEntity> query)
         {

--- a/test/Rdd.Infra.Tests/Storage/StorageTests.cs
+++ b/test/Rdd.Infra.Tests/Storage/StorageTests.cs
@@ -66,7 +66,7 @@ namespace Rdd.Infra.Tests.Storage
         [Fact]
         public async Task RepoOnNullFilterDoesNotFail()
         {
-            var repo = new Repository<User>(new InMemoryStorageService(), new OpenRightExpressionsHelper<User>());
+            var repo = new Repository<User>(new InMemoryStorageService(), new OpenRightExpressionsHelper<User>(), new IncludeApplicator());
             await repo.AddAsync(new User(), new Query<User> { Verb = Domain.Helpers.HttpVerbs.Post });
 
             var count = await repo.CountAsync(new Query<User> { Filter = null });

--- a/test/Rdd.Web.Tests/WebControllerTests.cs
+++ b/test/Rdd.Web.Tests/WebControllerTests.cs
@@ -17,7 +17,7 @@ namespace Rdd.Web.Tests
         {
             var storage = new InMemoryStorageService();
 
-            var repository = new Repository<IUser>(storage, new OpenRightExpressionsHelper<IUser>());
+            var repository = new Repository<IUser>(storage, new OpenRightExpressionsHelper<IUser>(), new IncludeApplicator());
             var collection = new ReadOnlyRestCollection<IUser, int>(repository);
             var appController = new ReadOnlyAppController<IUser, int>(collection);
 


### PR DESCRIPTION
Due to poor interactions between Z.ENtityFramework and [EFCore.BulkExtensions](https://github.com/borisdj/EFCore.BulkExtensions), this PR decouples the usage of Z.EntityFramework in an external assembly.
Usage is still opt-in.

- AddZEntityOptimizeInclude() should be used in startup registration
- query.ForceOptimizeIncludes(true) should be used in order to activate the Z.EF OptimizeIncludes