### PR TITLE
Fix memory leak

### DIFF
--- a/src/Rdd.Domain/Helpers/Expressions/ExpressionParser.cs
+++ b/src/Rdd.Domain/Helpers/Expressions/ExpressionParser.cs
@@ -99,11 +99,11 @@ namespace Rdd.Domain.Helpers.Expressions
             var parameter = Expression.Parameter(classType);
             if (typeof(IDictionary).IsAssignableFrom(classType))
             {
-                var dictionaryKey = Expression.Constant(member);
+                var dictionaryKey = ((Expression<Func<string>>)(() => member)).Body;
                 var itemProperty = GetPropertyInfo(classType, "Item");
                 var itemsExpression = Expression.Property(parameter, itemProperty, dictionaryKey);
 
-                return new ItemExpression { LambdaExpression = Expression.Lambda(itemsExpression, parameter) };
+                return new ItemExpression { LambdaExpression = Expression.Lambda(itemsExpression, parameter), Name = member };
             }
 
             var property = GetPropertyInfo(classType, member);

--- a/src/Rdd.Domain/Helpers/Expressions/ItemExpression.cs
+++ b/src/Rdd.Domain/Helpers/Expressions/ItemExpression.cs
@@ -11,7 +11,7 @@ namespace Rdd.Domain.Helpers.Expressions
 
         public IndexExpression IndexExpression => LambdaExpression?.Body as IndexExpression;
         public PropertyInfo Property => IndexExpression?.Indexer;
-        public string Name => (IndexExpression?.Arguments[0] as ConstantExpression)?.Value.ToString();
+        public string Name { get; set; }
 
         public Type ResultType => Property.PropertyType;
 


### PR DESCRIPTION
this really does not fix anything yet, just de-skip the test.

found a closure on dictionary keys, but that can't be what we saw in the logs